### PR TITLE
Add support for TrebleDAS / Terra15 Interrogators 

### DIFF
--- a/docs/user-guide/data-formats.md
+++ b/docs/user-guide/data-formats.md
@@ -20,7 +20,7 @@ os.chdir("../_data")
 
 ## Implemented file formats
 
-The formats that are currently implemented are: ASN, FEBUS, OPTASENSE and SINTELA. To read them you have to specifiy which one you want in the `engine` argument in {py:func}`xdas.open_dataarray` for a single file or {py:func}`xdas.open_mfdataarray` for multiple files:
+The formats that are currently implemented are: ASN, FEBUS, OPTASENSE, SINTELA and TERRA15. To read them you have to specifiy which one you want in the `engine` argument in {py:func}`xdas.open_dataarray` for a single file or {py:func}`xdas.open_mfdataarray` for multiple files:
 
 | DAS constructor   | `engine` argument |
 |:-----------------:|:-----------------:|
@@ -28,6 +28,7 @@ The formats that are currently implemented are: ASN, FEBUS, OPTASENSE and SINTEL
 | FEBUS             | `"febus"`         |
 | OPTASENSE         | `"optasense"`     |
 | SINTELA           | `"sintela"`       |
+| TERRA15           | `"terra15"`       |
 
 ## Extending *xdas* with your file format
 

--- a/xdas/io/__init__.py
+++ b/xdas/io/__init__.py
@@ -1,1 +1,1 @@
-from . import asn, febus, optasense, sintela
+from . import asn, febus, optasense, sintela, terra15

--- a/xdas/io/terra15.py
+++ b/xdas/io/terra15.py
@@ -7,13 +7,13 @@ from ..core.dataarray import DataArray
 from ..virtual import VirtualSource
 
 
-def read(fname):
+def read(fname,tz=timezone.utc):
     with h5py.File(fname, "r") as file:
         ti = np.datetime64(
-            datetime.fromtimestamp(file["data_product"]["gps_time"][0]), timezone.utc
+            datetime.fromtimestamp(file["data_product"]["gps_time"][0],tz=tz)
         ).astype("datetime64[ms]")
         tf = np.datetime64(
-            datetime.fromtimestamp(file["data_product"]["gps_time"][-1]), timezone.utc
+            datetime.fromtimestamp(file["data_product"]["gps_time"][-1],tz=tz)
         ).astype("datetime64[ms]")
         d0 = file.attrs["sensing_range_start"]
         dx = file.attrs["dx"]

--- a/xdas/io/terra15.py
+++ b/xdas/io/terra15.py
@@ -7,13 +7,13 @@ from ..core.dataarray import DataArray
 from ..virtual import VirtualSource
 
 
-def read(fname,tz=timezone.utc):
+def read(fname, tz=timezone.utc):
     with h5py.File(fname, "r") as file:
         ti = np.datetime64(
-            datetime.fromtimestamp(file["data_product"]["gps_time"][0],tz=tz)
+            datetime.fromtimestamp(file["data_product"]["gps_time"][0], tz=tz)
         ).astype("datetime64[ms]")
         tf = np.datetime64(
-            datetime.fromtimestamp(file["data_product"]["gps_time"][-1],tz=tz)
+            datetime.fromtimestamp(file["data_product"]["gps_time"][-1], tz=tz)
         ).astype("datetime64[ms]")
         d0 = file.attrs["sensing_range_start"]
         dx = file.attrs["dx"]

--- a/xdas/io/terra15.py
+++ b/xdas/io/terra15.py
@@ -1,0 +1,24 @@
+from datetime import UTC, datetime
+
+import h5py
+import numpy as np
+
+from ..core.dataarray import DataArray
+from ..virtual import VirtualSource
+
+
+def read(fname):
+    with h5py.File(fname, "r") as file:
+        ti = np.datetime64(
+            datetime.fromtimestamp(file["data_product"]["gps_time"][0]), UTC
+        ).astype("datetime64[ms]")
+        tf = np.datetime64(
+            datetime.fromtimestamp(file["data_product"]["gps_time"][-1]), UTC
+        ).astype("datetime64[ms]")
+        d0 = file.attrs["sensing_range_start"]
+        dx = file.attrs["dx"]
+        data = VirtualSource(file["data_product"]["data"])
+    nt, nd = data.shape
+    t = {"tie_indices": [0, nt - 1], "tie_values": [ti, tf]}
+    d = {"tie_indices": [0, nd - 1], "tie_values": [d0, d0 + (nd - 1) * dx]}
+    return DataArray(data, {"time": t, "distance": d})

--- a/xdas/io/terra15.py
+++ b/xdas/io/terra15.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 import h5py
 import numpy as np
@@ -10,10 +10,10 @@ from ..virtual import VirtualSource
 def read(fname):
     with h5py.File(fname, "r") as file:
         ti = np.datetime64(
-            datetime.fromtimestamp(file["data_product"]["gps_time"][0]), UTC
+            datetime.fromtimestamp(file["data_product"]["gps_time"][0]), timezone.utc
         ).astype("datetime64[ms]")
         tf = np.datetime64(
-            datetime.fromtimestamp(file["data_product"]["gps_time"][-1]), UTC
+            datetime.fromtimestamp(file["data_product"]["gps_time"][-1]), timezone.utc
         ).astype("datetime64[ms]")
         d0 = file.attrs["sensing_range_start"]
         dx = file.attrs["dx"]


### PR DESCRIPTION
This adds the ability to read DAS data produced by Terra15 interrogators.
- add a `read` function to `xdas.io.terra15`
- enable the use of `engine="terra15" for all `xdas.open_*` functions.
- add related documentation in the File formats section.