### PR TITLE
Add Data Streaming with ZeroMQ.

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -4,11 +4,12 @@
 :maxdepth: 1
 
 xdas
+atoms
+io
 fft
-signal
-processing
 parallel
+processing
+signal
 synthetics
 virtual
-atoms
 ```

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -1,0 +1,27 @@
+```{eval-rst}
+.. currentmodule:: xdas.io
+```
+
+# xdas.io
+
+```{eval-rst}
+.. autosummary::
+   :toctree: ../_autosummary
+
+    get_free_port
+```
+
+```{eval-rst}
+.. currentmodule:: xdas.io.asn
+```
+
+
+## ASN
+
+```{eval-rst}
+.. autosummary::
+   :toctree: ../_autosummary
+
+   ZMQPublisher
+   ZMQSubscriber
+```

--- a/docs/api/processing.md
+++ b/docs/api/processing.md
@@ -12,4 +12,6 @@
    DataArrayLoader
    RealTimeLoader
    DataArrayWriter
+   ZMQPublisher
+   ZMQSubscriber
 ```

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -10,4 +10,5 @@ interpolated-coordinates
 convert-displacement
 atoms
 processing
+streaming
 ```

--- a/docs/user-guide/streaming.md
+++ b/docs/user-guide/streaming.md
@@ -79,8 +79,13 @@ To reduce the volume of the transmitted data, compression is often useful. Xdas 
 
 import hdf5plugin
 
+address = f"tcp://localhost:{xd.io.get_free_port()}"
 encoding = {"chunks": (10, 10), **hdf5plugin.Zfp(accuracy=1e-6)}
 publisher = ZMQPublisher(address, encoding)  # Add encoding here, the rest is the same
 ```
 
+{py:class}`~xdas.io.asn.ZMQSubscriber`
 
+```{note}
+Xdas also implements the ZeroMQ protocol used by the OptoDAS interrogators by ASN. Equivalent {py:class}`~xdas.io.asn.ZMQPublisher` and {py:class}`~xdas.io.asn.ZMQSubscriber` can be found in {py:mod}`xdas.io.asn`. This can be useful get data in real-time from one instrument of that kind. Note that compression is not available with that protocol yet.
+```

--- a/docs/user-guide/streaming.md
+++ b/docs/user-guide/streaming.md
@@ -1,0 +1,86 @@
+---
+file_format: mystnb
+kernelspec:
+  name: python3
+---
+
+# Streaming data 
+
+Xdas allows to stream data over any network using [ZeroMQ](https://zeromq.org). Xdas use the Publisher and Subscriber patterns meaning that on one node the data is published and that any number of subscribers can receive the data stream. 
+
+Streaming data with Xdas is done by simply dumping each chunk to NetCDF binaries and to send those as packets. This ensure that each packet is self described and that feature such as compression are available (which can be very helpful to minimize the used bandwidth). 
+
+Xdas implements the {py:class}`~xdas.processing.ZMQPublisher` and {py:class}`~xdas.processing.ZMQSubscriber`.Those object can respectively be used as a Writer and a Loader as described in the [](processing) section. Both are initialized by giving an network address. The publisher use the `submit` method to send packets while the subscriber is an infinite iterator that yields packets.
+
+In this section, we will mimic the use of several machine by using multithreading, where each thread is supposed to be a different machine. In real-life application, the publisher and subscriber are generally called in different machine or software.
+
+## Simple use case
+
+```{code-cell}
+import threading
+import time
+
+import xdas as xd
+from xdas.processing import ZMQPublisher, ZMQSubscriber
+```
+
+First we generate some data and split it into packets
+
+```{code-cell}
+da = xd.synthetics.dummy()
+packets = xd.split(da, 5)
+```
+
+We then publish the packets on machine 1.
+
+```{code-cell}
+address = f"tcp://localhost:{xd.io.get_free_port()}"
+publisher = ZMQPublisher(address)
+
+def publish():
+    for packet in packets:
+        publisher.submit(packet)
+        # give a chance to the subscriber to connect in time and to get the last packet
+        time.sleep(0.1)  
+
+machine1 = threading.Thread(target=publish)
+machine1.start()
+```
+
+Let's receive the packets on machine 2.
+
+```{code-cell}
+subscriber = ZMQSubscriber(address)
+
+packets = []
+
+def subscribe():
+    for packet in subscriber:
+        packets.append(packet)
+
+machine2 = threading.Thread(target=subscribe)
+machine2.start()
+```
+
+Now we wait for machine 1 to finish sending its packet and see if everything went well.
+
+```{code-cell}
+machine1.join()
+print(f"We received {len(packets)} packets!")
+assert xd.concatenate(packets).equals(da)
+```
+
+## Using encoding
+
+To reduce the volume of the transmitted data, compression is often useful. Xdas enable the use of the ZFP algorithm when storing data but also when streaming it. Encoding is declared the same way.
+
+```{code-cell}
+:tags: [remove-output]
+
+import hdf5plugin
+
+encoding = {"chunks": (10, 10), **hdf5plugin.Zfp(accuracy=1e-6)}
+publisher = ZMQPublisher(address, encoding)  # Add encoding here, the rest is the same
+```
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "watchdog",
     "xarray",
     "xinterp",
+    "pyzmq",
 ]
 
 [project.optional-dependencies]

--- a/tests/io/test_asn.py
+++ b/tests/io/test_asn.py
@@ -1,1 +1,174 @@
-# TODO
+import time
+import numpy as np
+
+import xdas as xd
+from xdas.io.asn import ZMQPublisher, ZMQSubscriber
+import socket
+import json
+import zmq
+
+import threading
+
+from concurrent.futures import ThreadPoolExecutor
+
+executor = ThreadPoolExecutor()
+
+
+def get_free_address():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        port = s.getsockname()[1]
+    address = f"tcp://localhost:{port}"
+    return address
+
+
+coords = {
+    "time": {
+        "tie_indices": [0, 99],
+        "tie_values": [
+            np.datetime64("2020-01-01T00:00:00.000"),
+            np.datetime64("2020-01-01T00:00:09.900"),
+        ],
+    },
+    "distance": {"tie_indices": [0, 9], "tie_values": [0.0, 90.0]},
+}
+
+da_float32 = xd.DataArray(
+    np.random.randn(100, 10).astype("float32"),
+    coords,
+)
+
+da_int16 = xd.DataArray(
+    np.random.randn(100, 10).astype("int16"),
+    coords,
+)
+
+
+class TestZMQPublisher:
+    def test_get_header(self):
+        header = ZMQPublisher.get_header(da_float32)
+        assert header["bytesPerPackage"] == 40
+        assert header["nPackagesPerMessage"] == 100
+        assert header["nChannels"] == 10
+        assert header["dataType"] == "float"
+        assert header["dx"] == 10.0
+        assert header["dt"] == 0.1
+        assert header["dtUnit"] == "s"
+        assert header["dxUnit"] == "m"
+        assert header["roiTable"] == [{"roiStart": 0, "roiEnd": 9, "roiDec": 1}]
+        header = ZMQPublisher.get_header(da_int16)
+        assert header["dataType"] == "short"
+
+    def test_init_conect_set_header(self):
+        address = get_free_address()
+        pub = ZMQPublisher(address)
+        pub.submit(da_float32)
+        assert pub.header == ZMQPublisher.get_header(da_float32)
+
+    def test_send_header(self):
+        address = get_free_address()
+        pub = ZMQPublisher(address)
+        pub.submit(da_float32)
+        socket = self.get_socket(address)
+        pub.submit(da_float32)  # a packet must be sent once subscriber is connected
+        assert socket.recv() == json.dumps(pub.header).encode("utf-8")
+
+    def test_send_data(self):
+        address = get_free_address()
+        pub = ZMQPublisher(address)
+        pub.submit(da_float32)
+        socket = self.get_socket(address)
+        pub.submit(da_float32)  # a packet must be sent once subscriber is connected
+        socket.recv()
+        message = socket.recv()
+        assert message[:8] == da_float32["time"][0].values.astype("M8[ns]").tobytes()
+        assert message[8:] == da_float32.data.tobytes()
+
+    def test_send_chunks(self):
+        address = get_free_address()
+        pub = ZMQPublisher(address)
+        chunks = xd.split(da_float32, 10)
+        pub.submit(chunks[0])
+        time.sleep(0.001)
+        socket = self.get_socket(address)
+        for chunk in chunks[1:]:
+            pub.submit(chunk)
+            time.sleep(0.001)
+        assert socket.recv() == json.dumps(pub.header).encode("utf-8")
+        for chunk in chunks[1:]:  # first was sent before subscriber connected
+            message = socket.recv()
+            assert message[:8] == chunk["time"][0].values.astype("M8[ns]").tobytes()
+            assert message[8:] == chunk.data.tobytes()
+
+    def test_several_subscribers(self):
+        address = get_free_address()
+        pub = ZMQPublisher(address)
+        chunks = xd.split(da_float32, 10)
+        pub.submit(chunks[0])
+        time.sleep(0.001)
+        socket1 = self.get_socket(address)
+        for chunk in chunks[1:5]:
+            pub.submit(chunk)
+            time.sleep(0.001)
+        socket2 = self.get_socket(address)
+        for chunk in chunks[5:]:
+            pub.submit(chunk)
+            time.sleep(0.001)
+        assert socket1.recv() == json.dumps(pub.header).encode("utf-8")
+        for chunk in chunks[1:]:  # first was sent before subscriber connected
+            message = socket1.recv()
+            assert message[:8] == chunk["time"][0].values.astype("M8[ns]").tobytes()
+            assert message[8:] == chunk.data.tobytes()
+        assert socket2.recv() == json.dumps(pub.header).encode("utf-8")
+        for chunk in chunks[5:]:  # first was sent before subscriber connected
+            message = socket2.recv()
+            assert message[:8] == chunk["time"][0].values.astype("M8[ns]").tobytes()
+            assert message[8:] == chunk.data.tobytes()
+
+    def test_change_header(self):
+        address = get_free_address()
+        pub = ZMQPublisher(address)
+        chunks = xd.split(da_float32, 10)
+        pub.submit(chunks[0])
+        time.sleep(0.001)
+        socket = self.get_socket(address)
+        for chunk in chunks[1:5]:
+            pub.submit(chunk)
+            header1 = pub.header
+            time.sleep(0.001)
+        for chunk in chunks[5:]:
+            pub.submit(chunk.isel(distance=slice(0, 5)))
+            header2 = pub.header
+            time.sleep(0.001)
+        assert socket.recv() == json.dumps(header1).encode("utf-8")
+        for chunk in chunks[1:5]:  # first was sent before subscriber connected
+            message = socket.recv()
+            assert message[:8] == chunk["time"][0].values.astype("M8[ns]").tobytes()
+            assert message[8:] == chunk.data.tobytes()
+        assert socket.recv() == json.dumps(header2).encode("utf-8")
+        for chunk in chunks[5:]:  # first was sent before subscriber connected
+            message = socket.recv()
+            assert message[:8] == chunk["time"][0].values.astype("M8[ns]").tobytes()
+            assert message[8:] == chunk.isel(distance=slice(0, 5)).data.tobytes()
+
+    def get_socket(self, address):
+        socket = zmq.Context().socket(zmq.SUB)
+        socket.connect(address)
+        socket.setsockopt(zmq.SUBSCRIBE, b"")
+        time.sleep(0.001)
+        return socket
+
+
+# class TestZMQSubscriber:
+#     def test_init_connect_update_header(self):
+#         address = get_free_address()
+#         pub = ZMQPublisher(address)
+#         pub.submit(da_float32)
+#         sub = ZMQSubscriber(address)
+#         assert sub.packet_size == 40
+#         assert sub.shape == (100, 10)
+#         assert sub.format == "1000f"
+#         assert sub.distance == {"tie_indices": [0, 9], "tie_values": [0.0, 90.0]}
+#         assert sub.dt == 0.1
+#         assert sub.nt == 100
+#         pub.socket.close()

--- a/tests/io/test_asn.py
+++ b/tests/io/test_asn.py
@@ -218,6 +218,17 @@ class TestZMQSubscriber:
             result = next(sub2)
             assert result.equals(chunk)
 
+    def test_change_header(self):
+        address = get_free_address()
+        pub = ZMQPublisher(address)
+        chunks = xd.split(da_float32, 5)
+        chunks = [chunk.isel(distance=slice(0, 5)) for chunk in chunks[:2]] + chunks[2:]
+        threading.Thread(target=self.publish, args=(pub, chunks)).start()
+        sub = ZMQSubscriber(address)
+        for chunk in chunks:
+            result = next(sub)
+            assert result.equals(chunk)
+
     def publish(self, pub, chunks):
         for chunk in chunks:
             time.sleep(0.001)

--- a/tests/io/test_asn.py
+++ b/tests/io/test_asn.py
@@ -229,6 +229,16 @@ class TestZMQSubscriber:
             result = next(sub)
             assert result.equals(chunk)
 
+    def test_iter(self):
+        address = get_free_address()
+        pub = ZMQPublisher(address)
+        chunks = xd.split(da_float32, 5)
+        threading.Thread(target=self.publish, args=(pub, chunks)).start()
+        sub = ZMQSubscriber(address)
+        sub = (chunk for _, chunk in zip(range(5), sub))
+        result = xd.concatenate([chunk for chunk in sub])
+        assert result.equals(da_float32)
+
     def publish(self, pub, chunks):
         for chunk in chunks:
             time.sleep(0.001)

--- a/tests/io/test_asn.py
+++ b/tests/io/test_asn.py
@@ -79,10 +79,15 @@ class TestZMQPublisher:
         pub.submit(da_float32)
         socket = self.get_socket(address)
         pub.submit(da_float32)  # a packet must be sent once subscriber is connected
-        socket.recv()
+        socket.recv()  # header
         message = socket.recv()
         assert message[:8] == da_float32["time"][0].values.astype("M8[ns]").tobytes()
         assert message[8:] == da_float32.data.tobytes()
+        pub.submit(da_int16)
+        socket.recv()  # header
+        message = socket.recv()
+        assert message[:8] == da_int16["time"][0].values.astype("M8[ns]").tobytes()
+        assert message[8:] == da_int16.data.tobytes()
 
     def test_send_chunks(self):
         address = get_free_address()

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -170,12 +170,12 @@ class TestDataFrameWriter:
 
 class TestZMQ:
     def _publish_and_subscribe(self, packets, address, encoding=None):
-        publisher = ZMQPublisher(address)
+        publisher = ZMQPublisher(address, encoding)
 
         def publish():
             for packet in packets:
                 time.sleep(0.001)
-                publisher.submit(packet, encoding=encoding)
+                publisher.submit(packet)
 
         threading.Thread(target=publish).start()
 

--- a/xdas/io/__init__.py
+++ b/xdas/io/__init__.py
@@ -1,1 +1,2 @@
 from . import asn, febus, optasense, sintela
+from .core import get_free_port

--- a/xdas/io/asn.py
+++ b/xdas/io/asn.py
@@ -1,5 +1,9 @@
+import json
+import struct
+
 import h5py
 import numpy as np
+import zmq
 
 from ..core.dataarray import DataArray
 from ..virtual import VirtualSource
@@ -16,3 +20,144 @@ def read(fname):
     time = {"tie_indices": [0, nt - 1], "tie_values": [t0, t0 + (nt - 1) * dt]}
     distance = {"tie_indices": [0, nx - 1], "tie_values": [0.0, (nx - 1) * dx]}
     return DataArray(data, {"time": time, "distance": distance})
+
+
+class ZMQStream:
+    """
+    A class representing a ZeroMQ stream.
+
+    Parameters
+    ----------
+    address : str
+        The address to connect to.
+
+    Attributes
+    ----------
+    socket : zmq.Socket
+        The ZeroMQ socket used for communication.
+    packet_size : int
+        The size of each packet in bytes.
+    shape : tuple
+        The shape of the data array.
+    format : str
+        The format string used for unpacking the data.
+    distance : dict
+        The distance information.
+    dt : numpy.timedelta64
+        The sampling time interval.
+    nt : int
+        The number of time samples per message.
+
+    Methods
+    -------
+    connect(address)
+        Connects to the specified address.
+    get_message()
+        Receives a message from the socket.
+    is_packet(message)
+        Checks if the message is a valid packet.
+    update_header(message)
+        Updates the header information based on the received message.
+    stream_packet(message)
+        Processes a packet and returns a DataArray object.
+    """
+
+    def __init__(self, address):
+        """
+        Initializes a ZMQStream object.
+
+        Parameters
+        ----------
+        address : str
+            The address to connect to.
+        """
+        self.connect(address)
+        message = self.get_message()
+        self.update_header(message)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        message = self.get_message()
+        if not self.is_packet(message):
+            self.update_header(message)
+            return self.__next__()
+        else:
+            return self.stream_packet(message)
+
+    def connect(self, address):
+        context = zmq.Context()
+        socket = context.socket(zmq.SUB)
+        socket.connect(address)
+        socket.setsockopt_string(zmq.SUBSCRIBE, "")
+        self.socket = socket
+
+    def get_message(self):
+        return self.socket.recv()
+
+    def is_packet(self, message):
+        return len(message) == self.packet_size
+
+    def update_header(self, message):
+        header = json.loads(message.decode("utf-8"))
+
+        self.packet_size = 8 + header["bytesPerPackage"] * header["nPackagesPerMessage"]
+        self.shape = (header["nPackagesPerMessage"], header["nChannels"])
+
+        self.format = "%d%s" % (
+            header["nChannels"] * header["nPackagesPerMessage"],
+            "f" if header["dataType"] == "float" else "h",
+        )
+
+        roiTable = header["roiTable"][0]
+        di = roiTable["roiStart"] * header["dx"]
+        de = roiTable["roiEnd"] * header["dx"]
+        self.distance = {
+            "tie_indices": [0, header["nChannels"] - 1],
+            "tie_values": [di, de],
+        }
+
+        self.dt = float_to_timedelta(header["dt"], header["dtUnit"])
+        self.nt = header["nPackagesPerMessage"]
+
+    def stream_packet(self, message):
+        t0 = np.datetime64(struct.unpack("<Q", message[:8])[0], "ns")
+        data = np.array(struct.unpack(self.format, message[8:])).reshape(self.shape)
+        time = {
+            "tie_indices": [0, self.shape[0] - 1],
+            "tie_values": [t0, t0 + (self.shape[0] - 1) * self.dt],
+        }
+        return DataArray(data, {"time": time, "distance": self.distance})
+
+
+def float_to_timedelta(value, unit):
+    """
+    Converts a floating-point value to a timedelta object.
+
+    Parameters
+    ----------
+    value : float
+        The value to be converted.
+    unit : str
+        The unit of the value. Valid units are 'ns' (nanoseconds), 'us' (microseconds),
+        'ms' (milliseconds), and 's' (seconds).
+
+    Returns
+    -------
+    timedelta
+        The converted timedelta object.
+
+    Example
+    -------
+    >>> float_to_timedelta(1.5, 'ms')
+    numpy.timedelta64(1500000,'ns')
+    """
+    conversion_factors = {
+        "ns": 1e0,
+        "us": 1e3,
+        "ms": 1e6,
+        "s": 1e9,
+    }
+    conversion_factor = conversion_factors[unit]
+    return np.timedelta64(round(value * conversion_factor), "ns")

--- a/xdas/io/asn.py
+++ b/xdas/io/asn.py
@@ -207,6 +207,7 @@ class ZMQPublisher:
 
     @staticmethod
     def get_header(da):
+        da = da.transpose("time", "distance")
         header = {
             "bytesPerPackage": da.dtype.itemsize * da.shape[1],
             "nPackagesPerMessage": da.shape[0],
@@ -221,6 +222,7 @@ class ZMQPublisher:
         return header
 
     def send(self, da):
+        da = da.transpose("time", "distance")
         header = self.get_header(da)
         if self.header is None:
             self.header = header
@@ -234,6 +236,7 @@ class ZMQPublisher:
         self.send_message(message)
 
     def send_data(self, da):
+        da = da.transpose("time", "distance")
         t0 = da["time"][0].values.astype("datetime64[ns]")
         data = da.values
         message = t0.tobytes() + data.tobytes()

--- a/xdas/io/asn.py
+++ b/xdas/io/asn.py
@@ -22,9 +22,9 @@ def read(fname):
     return DataArray(data, {"time": time, "distance": distance})
 
 
-class ZMQStream:
+class ZMQSubscriber:
     """
-    A class representing a ZeroMQ stream.
+    A class used to subscribe to a ZeroMQ stream.
 
     Parameters
     ----------

--- a/xdas/io/asn.py
+++ b/xdas/io/asn.py
@@ -53,13 +53,14 @@ class ZMQSubscriber:
         >>> port = xd.io.get_free_port()
         >>> address = f"tcp://localhost:{port}"
         >>> publisher = ZMQPublisher(address)
-        >>> da = xd.synthetics.randn_wavefronts()
+
+        >>> da = xd.synthetics.dummy()
         >>> chunks = xd.split(da, 10)
 
         >>> def publish():
         ...     for chunk in chunks:
-        ...         publisher.submit(chunk)
         ...         time.sleep(0.001)  # so that the subscriber can connect in time
+        ...         publisher.submit(chunk)
         >>> threading.Thread(target=publish).start()
 
         >>> subscriber = ZMQSubscriber(address)
@@ -145,7 +146,7 @@ class ZMQPublisher:
     >>> import xdas as xd
     >>> from xdas.io.asn import ZMQPublisher
 
-    >>> da = xd.synthetics.randn_wavefronts()
+    >>> da = xd.synthetics.dummy()
 
     >>> port = xd.io.get_free_port()
     >>> address = f"tcp://localhost:{port}"

--- a/xdas/io/core.py
+++ b/xdas/io/core.py
@@ -1,0 +1,20 @@
+import socket
+
+
+def get_free_port():
+    """
+    Find and return a free port on the host machine.
+
+    This function creates a temporary socket, binds it to an available port
+    provided by the host, retrieves the port number, and then closes the socket.
+    This is useful for finding an available port for network communication.
+
+    Returns
+    -------
+    int:
+        A free port number on the host machine.
+
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]

--- a/xdas/processing/__init__.py
+++ b/xdas/processing/__init__.py
@@ -4,5 +4,7 @@ from .core import (
     DataArrayWriter,
     DataFrameWriter,
     RealTimeLoader,
+    ZMQPublisher,
+    ZMQSubscriber,
     process,
 )

--- a/xdas/processing/core.py
+++ b/xdas/processing/core.py
@@ -312,11 +312,15 @@ class ZMQPublisher:
 
     Examples
     --------
+    >>> import xdas as xd
     >>> from xdas.processing import ZMQPublisher
 
-    >>> address = "tcp://*:5556"
-    >>> pub = ZMQPublisher(address) # doctest: +SKIP
+    >>> publisher = ZMQPublisher("tcp://*:5556")
+    >>> packets = xd.split(xd.synthetics.randn_wavefronts(), 10)
 
+    >>> for n, da in enumerate(packets, start=1):
+    ...     print(f"Sending packet {n}")
+    ...     publisher.write(da)
     """
 
     def __init__(self, address):
@@ -353,11 +357,21 @@ class ZMQSubscriber:
 
     Examples
     --------
+    >>> import xdas as xd
     >>> from xdas.processing import ZMQSubscriber
 
-    >>> address = "tcp://localhost:5556"
-    >>> sub = ZMQSubscriber(address) # doctest: +SKIP
+    >>> subscriber = ZMQSubscriber("tcp://localhost:5556")
 
+    >>> packets = []
+    >>> for n, da in enumerate(subscriber, start=1):
+    ...     print(f"Received packet {n}")
+    ...     packets.append(da)
+    ...     if n == 10:
+    ...         break
+
+    >>> da = xd.concatenate(packets)
+
+    >>> assert da.equals(xd.synthetics.randn_wavefronts())
     """
 
     def __init__(self, address):

--- a/xdas/synthetics.py
+++ b/xdas/synthetics.py
@@ -145,7 +145,7 @@ def randn_wavefronts():
 
 def dummy(shape=(1000, 100)):
     starttime = np.datetime64("2024-01-01T00:00:00")
-    endtime = starttime + shape[0] * np.timedelta64(100, "ms")
+    endtime = starttime + (shape[0] - 1) * np.timedelta64(100, "ms")
     time = {"tie_indices": [0, shape[0] - 1], "tie_values": [starttime, endtime]}
     distance = {"tie_indices": [0, shape[1] - 1], "tie_values": [0.0, 1000.0]}
     return DataArray(

--- a/xdas/synthetics.py
+++ b/xdas/synthetics.py
@@ -45,6 +45,9 @@ def wavelet_wavefronts(
     True
 
     """
+    # ensure reporducibility
+    np.random.seed(42)
+
     # sampling
     starttime = np.datetime64(starttime).astype("datetime64[ns]")
     span = (np.timedelta64(6, "s"), 10000.0)  # (6 s, 10 km)
@@ -68,7 +71,6 @@ def wavelet_wavefronts(
         data[:, k] += sp.gausspulse(t - ttp[k] - t0, fc) / 2  # P is twice weaker
         data[:, k] += sp.gausspulse(t - tts[k] - t0, fc)
     data /= np.max(np.abs(data), axis=0, keepdims=True)  # normalize
-    np.random.seed(42)
     data += np.random.randn(*shape) / snr  # add noise
 
     # strain rate like response
@@ -96,6 +98,9 @@ def wavelet_wavefronts(
 
 
 def randn_wavefronts():
+    # ensure reporducibility
+    np.random.seed(42)
+
     # sampling
     resolution = (np.timedelta64(10, "ms"), 100.0)
     starttime = np.datetime64("2024-01-01T00:00:00").astype("datetime64[ns]")
@@ -119,7 +124,6 @@ def randn_wavefronts():
         data[:, k] += (t > (t0 + ttp[k])) * np.random.randn(shape[0]) / 2
         data[:, k] += (t > (t0 + tts[k])) * np.random.randn(shape[0])
     data /= np.max(np.abs(data), axis=0, keepdims=True)  # normalize
-    np.random.seed(42)
     data += np.random.randn(*shape) / snr  # add noise
 
     # pack data and coordinates as Database or DataCollection if chunking.

--- a/xdas/synthetics.py
+++ b/xdas/synthetics.py
@@ -141,3 +141,17 @@ def randn_wavefronts():
         },
     )
     return da
+
+
+def dummy(shape=(1000, 100)):
+    starttime = np.datetime64("2024-01-01T00:00:00")
+    endtime = starttime + shape[0] * np.timedelta64(100, "ms")
+    time = {"tie_indices": [0, shape[0] - 1], "tie_values": [starttime, endtime]}
+    distance = {"tie_indices": [0, shape[1] - 1], "tie_values": [0.0, 1000.0]}
+    return DataArray(
+        data=np.random.randn(*shape),
+        coords={
+            "time": time,
+            "distance": distance,
+        },
+    )


### PR DESCRIPTION
Allows to stream DataArray objects over the network using ZeroMQ. It implements both a native Xdas convention (that simply send netcdf files) and the ASN one. 

Add:
- xdas.processing.ZMQPublisher
- xdas.processing.ZMQSubscriber
- xdas.io.asn.ZMQPublisher
- xdas.io.asn.ZMQSubscriber
- xdas.io.get_free_port

Checklist:
- [x] Code
- [x] Tests
- [x] Documentation

