### PR TITLE
Fix decimattion of  virtual stacks

### DIFF
--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -1,0 +1,9 @@
+import numpy as np
+import xdas as xd
+import xdas.fft as xfft
+
+class TestRFFT:
+    def test_with_non_dimensional(self):
+        da = xd.synthetics.wavelet_wavefronts()
+        da["latitude"] = ("distance", np.arange(da.sizes["distance"]))
+        xfft.rfft(da, dim={"time": "frequency"})

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -1,6 +1,8 @@
 import numpy as np
+
 import xdas as xd
 import xdas.fft as xfft
+
 
 class TestRFFT:
     def test_with_non_dimensional(self):

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -6,4 +6,4 @@ class TestRFFT:
     def test_with_non_dimensional(self):
         da = xd.synthetics.wavelet_wavefronts()
         da["latitude"] = ("distance", np.arange(da.sizes["distance"]))
-        xfft.rfft(da, dim={"time": "frequency"})
+        xfft.rfft(da)

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,3 +1,6 @@
+import os
+import tempfile
+
 import numpy as np
 import scipy.signal as sp
 import xarray as xr
@@ -5,8 +8,6 @@ import xarray as xr
 import xdas
 import xdas.signal as xp
 from xdas.synthetics import wavelet_wavefronts
-import tempfile
-import os
 
 
 class TestSignal:

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -129,3 +129,39 @@ class TestSignal:
         da = wavelet_wavefronts()
         sos = sp.iirfilter(2, 0.5, btype="low", output="sos")
         xp.sosfiltfilt(sos, da, "time", padtype=None)
+
+    def test_filter(self):
+        da = wavelet_wavefronts()
+        axis = da.get_axis_num("time")
+        fs = 1 / xdas.get_sampling_interval(da, "time")
+        sos = sp.butter(
+            4,
+            [5, 10],
+            "band",
+            output="sos",
+            fs=fs,
+        )
+        data = sp.sosfilt(sos, da.values, axis=axis)
+        expected = da.copy(data=data)
+        result = xp.filter(
+            da,
+            [5, 10],
+            btype="band",
+            corners=4,
+            zerophase=False,
+            dim="time",
+            parallel=False,
+        )
+        assert result.equals(expected)
+        data = sp.sosfiltfilt(sos, da.values, axis=axis)
+        expected = da.copy(data=data)
+        result = xp.filter(
+            da,
+            [5, 10],
+            btype="band",
+            corners=4,
+            zerophase=True,
+            dim="time",
+            parallel=False,
+        )
+        assert result.equals(expected)

--- a/xdas/core/routines.py
+++ b/xdas/core/routines.py
@@ -967,7 +967,7 @@ def plot_availability(obj, dim="first", **kwargs):
     -------
     fig : plotly.graph_objects.Figure
         The timeline
-        
+
     Notes
     -----
     This function uses the `px.timeline` function from the `plotly.express` library.

--- a/xdas/fft.py
+++ b/xdas/fft.py
@@ -55,7 +55,8 @@ def fft(da, n=None, dim={"last": "spectrum"}, norm=None, parallel=None):
     data = func(da.values)
     coords = {
         newdim if name == olddim else name: f if name == olddim else da.coords[name]
-        for name in da.coords if (da[name].dim != olddim or name == olddim)
+        for name in da.coords
+        if (da[name].dim != olddim or name == olddim)
     }
     dims = tuple(newdim if dim == olddim else dim for dim in da.dims)
     return DataArray(data, coords, dims, da.name, da.attrs)
@@ -110,7 +111,8 @@ def rfft(da, n=None, dim={"last": "frequency"}, norm=None, parallel=None):
     data = func(da.values, n, axis, norm)
     coords = {
         newdim if name == olddim else name: f if name == olddim else da.coords[name]
-        for name in da.coords if (da[name].dim != olddim or name == olddim)
+        for name in da.coords
+        if (da[name].dim != olddim or name == olddim)
     }
     dims = tuple(newdim if dim == olddim else dim for dim in da.dims)
     return DataArray(data, coords, dims, da.name, da.attrs)

--- a/xdas/fft.py
+++ b/xdas/fft.py
@@ -55,7 +55,7 @@ def fft(da, n=None, dim={"last": "spectrum"}, norm=None, parallel=None):
     data = func(da.values)
     coords = {
         newdim if name == olddim else name: f if name == olddim else da.coords[name]
-        for name in da.coords
+        for name in da.coords if (da[name].dim != olddim or name == olddim)
     }
     dims = tuple(newdim if dim == olddim else dim for dim in da.dims)
     return DataArray(data, coords, dims, da.name, da.attrs)
@@ -110,7 +110,7 @@ def rfft(da, n=None, dim={"last": "frequency"}, norm=None, parallel=None):
     data = func(da.values, n, axis, norm)
     coords = {
         newdim if name == olddim else name: f if name == olddim else da.coords[name]
-        for name in da.coords
+        for name in da.coords if (da[name].dim != olddim or name == olddim)
     }
     dims = tuple(newdim if dim == olddim else dim for dim in da.dims)
     return DataArray(data, coords, dims, da.name, da.attrs)

--- a/xdas/signal.py
+++ b/xdas/signal.py
@@ -102,9 +102,9 @@ def filter(da, freq, btype, corners=4, zerophase=False, dim="last", parallel=Non
     fs = 1.0 / get_sampling_interval(da, dim)
     sos = sp.iirfilter(corners, freq, btype=btype, ftype="butter", output="sos", fs=fs)
     if zerophase:
-        func = parallelize((None, across), across, parallel)(sp.sosfilt)
-    else:
         func = parallelize((None, across), across, parallel)(sp.sosfiltfilt)
+    else:
+        func = parallelize((None, across), across, parallel)(sp.sosfilt)
     data = func(sos, da.values, axis=axis)
     return da.copy(data=data)
 

--- a/xdas/signal.py
+++ b/xdas/signal.py
@@ -708,10 +708,15 @@ def decimate(da, q, n=None, ftype="iir", zero_phase=True, dim="last", parallel=N
 
     """
     axis = da.get_axis_num(dim)
+    dim = da.dims[axis]  # TODO: this fist last thing is a bad idea...
     across = int(axis == 0)
     func = parallelize(across, across, parallel)(sp.decimate)
     data = func(da.values, q, n, ftype, axis, zero_phase)
-    return da[{dim: slice(None, None, q)}].copy(data=data)
+    coords = da.coords.copy()
+    for name in coords:
+        if coords[name].dim == dim:
+            coords[name] = coords[name][::q]
+    return DataArray(data, coords, da.dims, da.name, da.attrs)
 
 
 @atomized


### PR DESCRIPTION
Decimating a newly opened file failed. This is because when opening files with `xdas.open_mfdataarray` we get data as a virtual stack which does not currently implement stepped slicing. This fixes this problem by
- Fixing the decimation code by handling the coordinates more properly
- Adding a test to check that everything is OK. 