### PR TITLE
test coord repr

### DIFF
--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -299,9 +299,11 @@ class TestInterpCoordinate:
         )
         assert len(InterpCoordinate(dict(tie_indices=[], tie_values=[]))) == 0
 
-    def test_repr(self):
-        # TODO
-        pass
+    @pytest.mark.parametrize("valid_input", valid)
+    def test_repr(self, valid_input):
+        coord = InterpCoordinate(data=valid_input)
+        my_coord = repr(coord)
+        assert isinstance(my_coord, str)
 
     def test_equals(self):
         coord1 = InterpCoordinate({"tie_indices": [0, 8], "tie_values": [100.0, 900.0]})

--- a/xdas/core/coordinates.py
+++ b/xdas/core/coordinates.py
@@ -620,6 +620,8 @@ class InterpCoordinate(Coordinate):
                 start = format_datetime(self.tie_values[0])
                 end = format_datetime(self.tie_values[-1])
                 return f"{start} to {end}"
+            else:
+                return f"{self.tie_values[0]} to {self.tie_values[-1]}"
 
     def __getitem__(self, item):
         if isinstance(item, slice):


### PR DESCRIPTION
This PR tests the coord repr method for the valid coords. I noticed `InterpCoordiante` instances with integer tie_values failed to produce a str value, this PR fixes the issue. 