### PR TITLE
When reading multiple files, warn instead of raising on corrupted files.

### DIFF
--- a/xdas/core/routines.py
+++ b/xdas/core/routines.py
@@ -1,5 +1,6 @@
 import os
 import re
+import warnings
 from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from glob import glob
@@ -323,19 +324,27 @@ def open_mfdataarray(
         )
     max_workers = 1 if engine == "miniseed" else None  # TODO: dirty fix
     with ProcessPoolExecutor(max_workers=max_workers) as executor:
-        futures = [
-            executor.submit(open_dataarray, path, engine=engine, **kwargs)
+        futures_to_paths = {
+            executor.submit(open_dataarray, path, engine=engine, **kwargs): path
             for path in paths
-        ]
+        }
         if verbose:
             iterator = tqdm(
-                as_completed(futures),
-                total=len(futures),
+                as_completed(futures_to_paths),
+                total=len(futures_to_paths),
                 desc="Fetching metadata from files",
             )
         else:
-            iterator = as_completed(futures)
-        objs = [future.result() for future in iterator]
+            iterator = as_completed(futures_to_paths)
+        objs = []
+        for future in iterator:
+            try:
+                obj = future.result()
+            except Exception as e:
+                path = futures_to_paths[future]
+                warnings.warn(f"could not open {path}: {e}", RuntimeWarning)
+            else:
+                objs.append(obj)
     return combine_by_coords(objs, dim, tolerance, squeeze, None, verbose)
 
 


### PR DESCRIPTION
This PR fixes #27 

When reading multiple files with e.g.`open_mfdataarray`, if one file matching the given pattern was corrupted or coud not be openned as a data array for any reason, the entire process would fail and raise an Error. Now those functions only raise a warning for each file that could not be openned.