### PR TITLE
Fix: Correct dimension order in Optasense H5 reader

### DIFF
--- a/xdas/io/optasense.py
+++ b/xdas/io/optasense.py
@@ -13,7 +13,7 @@ def read(fname):
         tstart = np.datetime64(rawdata.attrs["PartStartTime"][:-1])
         tend = np.datetime64(rawdata.attrs["PartEndTime"][:-1])
         data = VirtualSource(rawdata)
-    nt, nd = data.shape
+    nd, nt = data.shape
     time = {"tie_indices": [0, nt - 1], "tie_values": [tstart, tend]}
     distance = {"tie_indices": [0, nd - 1], "tie_values": [0.0, (nd - 1) * dx]}
-    return DataArray(data, {"time": time, "distance": distance})
+    return DataArray(data, {"distance": distance, "time": time})


### PR DESCRIPTION
## Summary
Fixes incorrect dimension assignment in the Optasense H5 file reader that caused dimension mismatch errors when concatenating multiple files.

## Problem
The `read()` function in `xdas/io/optasense.py` incorrectly assigned dimensions as `nt, nd = data.shape`, but Optasense PRODML H5 files store data as `(channels, time_samples)` or `(distance, time)`.

This caused:
- Concatenated data to have mismatched coordinate sizes (e.g., 108000 time coords but 12000 data samples)
- `.isel(distance=idx)` operations to fail with: `ValueError: conflicting sizes for dimension time: size X in coords and size Y in data`

## Solution
Changed line 16 from:
```python
nt, nd = data.shape
```
to:
```python
nd, nt = data.shape
```

## Verification
Tested with Sintela Optasense data files:
- Raw H5 shape: `(2500, 12000)` = (2500 channels, 12000 time samples)
- Concatenation of 9 files now works correctly
- Channel selection with `.isel()` works without requiring transpose

## Test Data
- Format: Optasense PRODML H5 files
- RawData shape: `(2500, 12000)`
- Files concatenate correctly along time dimension