### PR TITLE
Automatic `open` function

### DIFF
--- a/docs/api/xdas.md
+++ b/docs/api/xdas.md
@@ -10,6 +10,7 @@
 .. autosummary::
    :toctree: ../_autosummary
 
+   open
    open_dataarray
    open_mfdataarray
    open_mfdatatree

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,7 @@ Xdas must first be imported along with other useful libraries:
 
 ```{code-cell}
 import numpy as np
-import xdas 
+import xdas as xd
 ```
 
 ## Dataset virtual consolidation
@@ -48,7 +48,7 @@ Most instruments usually produces datasets made out of a multitude of files, eac
 
 ### Linking multiple files 
 
-If you are considering a unique acquisition you can use {py:func}`~xdas.open_mfdataarray`. You can either pass a list of paths or a path pattern containing wildcards to specify which files must be linked together. The `engine` keyword indicates the format of the data. Xdas support a variety of DAS formats and it is easy to add support to any custom or missing format. See the [](user-guide/data-formats) section for more information. 
+If you are considering a unique acquisition you can use {py:func}`~xdas.open`. You can either pass a list of paths or a path pattern containing wildcards to specify which files must be linked together. The `engine` keyword indicates the format of the data. Xdas support a variety of DAS formats and it is easy to add support to any custom or missing format. See the [](user-guide/data-formats) section for more information. 
 
 In the example here, we have three files of interest in the current working directory:
 
@@ -59,7 +59,7 @@ ls 00*.h5
 We can link them like this:
 
 ```{code-cell}
-da = xdas.open_mfdataarray("00*.h5", engine=None)
+da = xd.open("00*.h5", engine=None)
 da
 ```
 
@@ -68,7 +68,7 @@ Xdas only loads the metadata from each file and returns a {py:class}`~xdas.DataA
 Note that if you want to create a single data collection object for multiple acquisitions (i.e. different instruments or several acquisition with different parameters), you can use the [DataCollection](user-guide/data-structures/datacollection) structure.  
 
 ```{note}
-For Febus users, converting native files into Xdas NetCDF format generally improves I/O operations and reduce the amount of data by a factor two. This can be done by looping over Febus files and running: `xdas.open_dataarray("path_to_febus_file.h5", engine="febus").to_netcdf("path_to_xdas_file.nc", virtual=False)`. The converted files can then be linked as described above.
+For Febus users, converting native files into Xdas NetCDF format generally improves I/O operations and reduce the amount of data by a factor two. This can be done by looping over Febus files and running: `xd.open("path_to_febus_file.h5", engine="febus").to_netcdf("path_to_xdas_file.nc", virtual=False)`. The converted files can then be linked as described above.
 ```
 
 ### Fixing small gaps and overlaps
@@ -103,7 +103,7 @@ Now that your dataset is ready to use, let's explore it!
 The consolidated virtual dataset can be fetched as if it was a regular file:
 
 ```{code-cell} 
-da = xdas.open_dataarray("da.nc")
+da = xd.open("da.nc")
 da
 ```
 
@@ -144,7 +144,7 @@ da.to_netcdf("chunked_and_compressed.nc", encoding=encoding)
 Reading compressed data is completely transparent, you do not need to specify anything.
 
 ```{code-cell}
-xdas.open_dataarray("chunked_and_compressed.nc")
+xd.open("chunked_and_compressed.nc")
 ```
 
 Note that you do not necessarily need to load it manually. Any step that requires to modify the data will automatically trigger the data importation.
@@ -169,7 +169,7 @@ You can apply most numpy functions to a data array. Xdas also have its own imple
 
 ```{code-cell}
 squared = np.square(da)
-mean = xdas.mean(da, "time")
+mean = xd.mean(da, "time")
 std = da.std("distance")
 ```
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,7 @@
 # Release notes
 
 ## 0.2.6
+- Add `xdas.open` that automatically which `xdas.open_*` function to use.
 - Add `pathlib.Path` support as input for all Xdas file-related functions and methods (@atrabattoni).
 
 ## 0.2.5

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,8 @@
 # Release notes
 
+## 0.2.6
+- Add `pathlib.Path` support as input for all Xdas file-related functions and methods.
+
 ## 0.2.5
 - Add SampleCoordinate for more SEED-like coordinates and refactor the coordinate backend (@atrabattoni).
 - Add `xdas.picking.tapered_selection` to extract windows around picks (@atrabattoni).

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,7 +1,7 @@
 # Release notes
 
 ## 0.2.6
-- Add `pathlib.Path` support as input for all Xdas file-related functions and methods.
+- Add `pathlib.Path` support as input for all Xdas file-related functions and methods (@atrabattoni).
 
 ## 0.2.5
 - Add SampleCoordinate for more SEED-like coordinates and refactor the coordinate backend (@atrabattoni).
@@ -9,7 +9,7 @@
 - Add `create_dirs` to `.to_netcdf` methods to create intermediate directories (@aurelienfalco).
 - Add support for multiple ROI for ASN engine (@martijnende).
 - `tolerance` can now be passed as seconds for datetime64 coordinates (@martijnende, @atrabattoni)
-- Add suppport for python 3.14, numpy 2.4 and obspy 1.4.2 incompatibilities and add `xdas.__version__` (@atrabatto).
+- Add suppport for python 3.14, numpy 2.4 and obspy 1.4.2 incompatibilities and add `xdas.__version__` (@atrabattoni).
 
 ## 0.2.4
 - Add StreamWriter to write long time series to miniSEED (@marbail).

--- a/docs/user-guide/convert-displacement.md
+++ b/docs/user-guide/convert-displacement.md
@@ -21,7 +21,7 @@ more details.
 First open some data and convert it to xarray format.
 
 ```{code-cell} 
-strain_rate = xd.open_dataarray("sample.nc")
+strain_rate = xd.open("sample.nc")
 strain_rate.plot(yincrease=False, vmin=-0.5, vmax=0.5);
 ```
 

--- a/docs/user-guide/data-formats.md
+++ b/docs/user-guide/data-formats.md
@@ -20,7 +20,7 @@ os.chdir("../_data")
 
 ## Implemented file formats
 
-Here below the list of formats that are currently implemented. All HDF5 based formats support native virtualization. Other formats support Dask virtualization. Please refer to the [](virtual-datasets) section. To read a them you have to specify which one you want in the `engine` argument in {py:func}`xdas.open_dataarray` for a single file or {py:func}`xdas.open_mfdataarray` for multiple files.
+Here below the list of formats that are currently implemented. All HDF5 based formats support native virtualization. Other formats support Dask virtualization. Please refer to the [](virtual-datasets) section. To read a them you have to specify which one you want in the `engine` argument in {py:func}`xdas.open`.
 
 Xdas support the following DAS formats:
 
@@ -43,21 +43,21 @@ It also implements its own format and support miniSEED:
 
 ```{warning}
 Due to poor documentation of the various version of the Febus format, it is recommended to manually provide the required trimming and the position of the timestamps within each block. For example to trim 100 samples on both side of each block and to set the timestamp location at the center of the block for a block of 2000 samples:
-`xdas.open_dataarray("path.h5", engine="febus", overlaps=(100, 100), offset=1000)`
+`xdas.open("path.h5", engine="febus", overlaps=(100, 100), offset=1000)`
 ```
 
 ## Extending *xdas* with your file format
 
 *xdas* insists on its extensibility, the power is in the hands of the users. Extending *xdas* usually consists of writing few-line-of-code-long functions. The process consists in dealing with the two main aspects of a {py:class}`xarray.DataArray`: unpacking the data and coordinates objects, eventually processing them and packing them back into a Database object. 
 
-To add a new file format the user can specify a function that read one file and outputs a {py:class}`xarray.DataArray`. This function can then be passed as an engine keyword argument to the {py:func}`xdas.open_dataarray` or {py:func}`xdas.open_mfdataarray` functions. The reading function must fetch and parse the data and coordinates information. 
+To add a new file format the user can specify a function that read one file and outputs a {py:class}`xarray.DataArray`. This function can then be passed as an engine keyword argument to the {py:func}`xdas.open` function. The reading function must fetch and parse the data and coordinates information. 
 
 Adding the support for a new file format generally consists in providing the path to the data array and parsing the start time and spatial and temporal spacing as in the example below.
 
 ```{code-cell}
 import h5py
 import numpy as np
-import xdas
+import xdas as xd
 from xdas import DataArray
 from xdas.virtual import VirtualSource
 
@@ -73,8 +73,8 @@ def read(fname):
   return DataArray(data, {"time": t, "distance": d})
 
 # Replace "other_format.hdf5" by the path of your file
-da = xdas.open_dataarray("other_format.hdf5", engine=read)
+da = xd.open("other_format.hdf5", engine=read)
 da
 ```
 
-This example is for one file, please use {py:func}`xdas.open_mfdataarray`. Indicate the path of your files with a '*' before the file format if all your files are in the same folder or pass a list of paths.
+This example is for one file. For multi-file datasets please indicate the path of your files with a '*' before the file format if all your files are in the same folder or pass a list of paths.

--- a/docs/user-guide/data-structures/dataarray.md
+++ b/docs/user-guide/data-structures/dataarray.md
@@ -26,7 +26,7 @@ Other important attributes are:
 - `name`: the name of the array to specify the quantity stored (e.g., `"velocity"`).
 - `attribute`: a dictionary containing metadata. Note that *xdas* does not use those metadata. It tries to keep as much as possible the information stored there as the `DataArray` is manipulated but it is up to the user to update information there if needed.
 
-In the following examples, we use only one `DataArray`, if you have several `DataArray`s, please use the multi-file version of the opening function: {py:func}`~xdas.open_mfdataarray`. You will just have to adapt the paths argument.
+In the following examples, we use only one `DataArray`, if you have several `DataArray`s, you will just have to adapt the paths argument.
 
 ## Creating a DataArray
 
@@ -35,14 +35,14 @@ The user can wrap together an n-dimensional array and some related coordinates. 
 
 ```{code-cell}
 import numpy as np
-import xdas
+import xdas as xd
 
 data = np.zeros((6000, 1000))
 starttime = np.datetime64("2023-01-01T00:00:00")
 endtime = starttime + np.timedelta64(10, "ms") * (data.shape[0] - 1)
 distance = 5.0 * np.arange(data.shape[1])
 
-da = xdas.DataArray(
+da = xd.DataArray(
     data=data,
     coords={
         "time": {
@@ -65,12 +65,12 @@ da.to_netcdf("dataarray.nc", virtual=None)  # try to write virtual, here it's im
 
 ## Reading a DataArray from disk
 
-Xdas can read several DAS file format with {py:func}`~xdas.open_dataarray` along with its own format. Xdas uses the netCDF4 format with CF conventions. By default Xdas assumes that files are Xdas NetCDF format. If not the case the `engine` argument must be passed.
+Xdas can read several DAS file format with {py:func}`~xdas.open` along with its own format. Xdas uses the netCDF4 format with CF conventions. By default Xdas assumes that files are Xdas NetCDF format. If not the case the `engine` argument must be passed.
 
 To learn how to read your custom DAS data format with *xdas*, please see the chapter on [](../data-formats.md).
 
 ```{code-cell}
-da = xdas.open_dataarray("dataarray.nc", engine=None)  # by default Xdas NetCDF
+da = xd.open("dataarray.nc", engine=None)  # by default Xdas NetCDF
 da
 ```
 
@@ -92,7 +92,7 @@ da.to_netcdf("chunked_and_compressed.nc", virtual=False, encoding=encoding)
 Reading compressed data is completely transparent, you do not need to specify anything.
 
 ```{code-cell}
-xdas.open_dataarray("chunked_and_compressed.nc")
+xd.open("chunked_and_compressed.nc")
 ```
 
 Note that the indicated data size is the uncompressed data size.

--- a/docs/user-guide/data-structures/datacollection.md
+++ b/docs/user-guide/data-structures/datacollection.md
@@ -35,13 +35,13 @@ In the example, our `DataCollection` will be a sequence of {py:class}`xdas.DataA
 
 ```{code-cell}
 import numpy as np
-import xdas
+import xdas as xd
 
 # Reopen dataarray from previous section as a virtual source
-da = xdas.open_dataarray("dataarray.nc") 
+da = xd.open("dataarray.nc") 
 
 # Create a DataCollection
-dc = xdas.DataCollection(
+dc = xd.DataCollection(
     {
         "event_1": da.sel(time=slice("2023-01-01T00:00:10", "2023-01-01T00:00:20")), 
         "event_2": da.sel(time=slice("2023-01-01T00:00:40", "2023-01-01T00:00:50")),
@@ -61,26 +61,20 @@ dc.to_netcdf("datacollection.nc", virtual=False)
 
 ```{code-cell}
 # Read a DataCollection
-dc = xdas.open_datacollection("datacollection.nc")
+dc = xd.open("datacollection.nc")
 dc
 ```
 
 ## Case B: DataCollection comprising a set of acquisitions
 
-You can also create a DataCollection to gather different acquisitions on a same fiber with {py:func}`xdas.open_mfdatatree`. This function opens a directory tree structure as a data collection. 
+You can also create a DataCollection to gather different acquisitions on a same fiber with {py:func}`xdas.open`to opens a directory tree structure as a data collection. 
 The tree structure is described by a path descriptor provided as a string
 containing placeholders. Two flavors of placeholder can be provided:
 
-- `{field}`: this level of the tree will behave as a dict. It will use the
-directory/file names as keys.
-- `[field]`: this level of the tree will behave as a list. The directory/file
-names are not considered (as if the placeholder was replaced by a `*`) and
-files are gathered and combined as if using {py:func}`xdas.open_mfdataarray`.
+- `{field}`: this level of the tree will behave as a dict. It will use the directory/file names as keys.
+- `[field]`: this level of the tree will behave as a list. The directory/file names are not considered (as if the placeholder was replaced by a `*`) and files are gathered and combined as usual.
 
-Several dict placeholders with different names can be provided. They must be
-followed by one or more list placeholders that must share a unique name. The
-resulting data collection will be a nesting of dicts down to the lower level
-which will be a list of dataarrays.
+Several dict placeholders with different names can be provided. They must be followed by one or more list placeholders that must share a unique name. The resulting data collection will be a nesting of dicts down to the lower level which will be a list of dataarrays.
 
 ### Gather all your DataCollections
 
@@ -90,7 +84,7 @@ If your data paths are something like: "/data/REKA/RK1/20231119/proc/*.hdf5" and
 
 ```python
 path = "/data/{network}/{cable}/20231119/proc/[acquisition].hdf5"
-dc = xdas.open_mfdatatree(path, engine='asn')
+dc = xd.open(path, engine='asn')
 dc
 ```
 ```text
@@ -113,7 +107,7 @@ dc.to_netcdf("datacollection.nc", virtual=True)
 
 ```python
 # Read your global DataCollection with open_datacollection
-dc = xdas.open_datacollection("datacollection.nc")
+dc = xd.open("datacollection.nc")
 dc
 ```
 ```text
@@ -130,7 +124,7 @@ Network:
             0: <xdas.DataArray (time: 54000, distance: 10000)>
 ```
 
-If you have several DataCollections, you can gather them in one file using {py:func}`xdas.open_mfdatacollection` and write it to one single DataCollection.
+If you have several DataCollections, you can gather them in one file using {py:func}`xdas.open` and write it to one single DataCollection.
 
 ### Extend your DataCollection
 
@@ -138,10 +132,10 @@ You can extend your {py:class}`xdas.DataCollection` by inserting new {py:class}`
 
 ```python
 # Read your global DataCollection with open_datacollection
-dc = xdas.open_datacollection("datacollection.nc")
+dc = xd.open("datacollection.nc")
 
 # Read the dataarray you want to add
-da = xdas.open_dataarray("dataarray.nc")
+da = xd.open("dataarray.nc")
 da
 ```
 ```text

--- a/docs/user-guide/miniseed.md
+++ b/docs/user-guide/miniseed.md
@@ -71,7 +71,7 @@ This part encourages experimenting with seismic data. Depending on the most comm
 
 We will start by exploring a synthetic dataset composed of 7 stations, each with 3 channels (HHZ, HHN, HHE). Each trace for each station and channel is stored in multiple one-minute-long files. Some files are missing, resulting in data gaps. The sampling rate is 100 Hz. The data is organized in a directory structure that groups files by station.
 
-To open the dataset, we will use the `open_mfdatatree` function. This function takes a pattern that describes the directory structure and file names. The pattern is a string containing placeholders for the network, station, location, channel, start time, and end time. Placeholders for named fields are enclosed in curly braces, while simple brackets are used for varying parts of the file name that will be concatenated into different acquisitions (meant for changes in acquisition parameters).
+To open the dataset, we will provide a pattern that describes the directory structure and file names to the `xdas.open` function. The pattern is a string containing placeholders for the network, station, location, channel, start time, and end time. Placeholders for named fields are enclosed in curly braces, while simple brackets are used for varying parts of the file name that will be concatenated into different acquisitions (meant for changes in acquisition parameters).
 
 Next, we will plot the availability of the dataset.
 
@@ -81,7 +81,7 @@ Next, we will plot the availability of the dataset.
 import xdas as xd
 
 pattern = "NX/{station}/NX.{station}.00.{channel}__[acquisition].mseed"
-dc = xd.open_mfdatatree(pattern, engine="miniseed")
+dc = xd.open(pattern, engine="miniseed")
 xd.plot_availability(dc, dim="time")
 ```
 ```{code-cell}

--- a/docs/user-guide/virtual-datasets.md
+++ b/docs/user-guide/virtual-datasets.md
@@ -39,7 +39,7 @@ When opening a virtual dataset, this later will appear as a {py:class}`VirtualSo
 
 ## Use cases
 
-To handle individual files, multiple files, and virtual datasets, *xdas* offers the following routines:
+The generic {py:func}`xdas.open` funtion should cover all your needs. But you can specify how to handle individual files, multiple files, and virtual datasets, by picking one of the following routines:
 
 | Function                             | Output                           | Description                                                                 |
 |--------------------------------------|----------------------------------|-----------------------------------------------------------------------------|
@@ -53,26 +53,26 @@ Please refer to the [](data-structures/datacollection.md) section for the functi
 
 ## Linking multi-file datasets
 
-Multiple physical data files can be opened simultaneously with the {py:func}`xdas.open_mfdataarray`:
+Multiple physical data files can be opened simultaneously with {py:func}`xdas.open`:
 
 ```{code-cell}
 :tags: [remove-stdout,remove-stderr]
 
-da = xd.open_mfdataarray("00*.nc")
+da = xd.open("00*.nc")
 da
 ```
 
-Here, `*` is a wildcard operator. `open_mfdataarray` only creates file handles and loads basic metadata, but does not directly load the underlying DAS data in memory. Hence this method can open an arbitrary number
+Here, `*` is a wildcard operator. `xdas.open` only creates file handles and loads basic metadata, but does not directly load the underlying DAS data in memory. Hence this method can open an arbitrary number
 of files with no concern over memory allocation. Next, the DataArray can be written to disk as a single dataset. The `virtual` argument ensures that only the pointers to the original data files are written to disk (otherwise the whole data set will be written to disk):
 
 ```{code-cell}
 da.to_netcdf("vds.nc", virtual=True)
 ```
 
-It can then be read again as a single file using {py:func}`xdas.open_dataarray`:
+It can then be read again as a single file using {py:func}`xdas.open`:
 
 ```{code-cell}
-xd.open_dataarray("vds.nc")
+xd.open("vds.nc")
 ```
 
 ```{hint}

--- a/tests/coordinates/test_sampled.py
+++ b/tests/coordinates/test_sampled.py
@@ -869,7 +869,7 @@ class TestSampledCoordinateToNetCDF:
 
         with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as file:
             expected.to_netcdf(file.name)
-            result = xd.open_dataarray(file.name)
+            result = xd.open(file.name)
             assert result.equals(expected)
 
 

--- a/tests/dask/test_core.py
+++ b/tests/dask/test_core.py
@@ -1,7 +1,3 @@
-import os
-from glob import glob
-from tempfile import TemporaryDirectory
-
 import dask
 import numpy as np
 
@@ -58,9 +54,9 @@ class TestIO:
         expected = np.random.rand(3, 10)
         chunks = np.split(expected, 5, axis=1)
         for idx, chunk in enumerate(chunks):
-            np.save(os.path.join(tmpdir, f"chunk_{idx}.npy"), chunk)
-        paths = sorted(glob(os.path.join(tmpdir, "*.npy")))
-        chunks = [dask.delayed(np.load)(path) for path in paths]
+            np.save(tmpdir / f"chunk_{idx}.npy", chunk)
+        paths = sorted(tmpdir.glob("*.npy"))
+        chunks = [dask.delayed(np.load)(str(path)) for path in paths]
         chunks = [
             dask.array.from_delayed(chunk, shape=(3, 2), dtype=expected.dtype)
             for chunk in chunks
@@ -69,18 +65,16 @@ class TestIO:
         assert np.array_equal(data.compute(), expected)
         return expected, data
 
-    def test_dict(self):
-        with TemporaryDirectory() as tmpdir:
-            expected, data = self.generate(tmpdir)
-            result = from_dict(to_dict(data))
-            assert np.array_equal(result.compute(), expected)
-            sliced = result[:, 0]
-            assert np.array_equal(sliced.compute(), expected[:, 0])
+    def test_dict(self, tmp_path):
+        expected, data = self.generate(tmp_path)
+        result = from_dict(to_dict(data))
+        assert np.array_equal(result.compute(), expected)
+        sliced = result[:, 0]
+        assert np.array_equal(sliced.compute(), expected[:, 0])
 
-    def test_serial(self):
-        with TemporaryDirectory() as tmpdir:
-            expected, data = self.generate(tmpdir)
-            result = loads(dumps(data))
-            assert np.array_equal(result.compute(), expected)
-            sliced = result[:, 0]
-            assert np.array_equal(sliced.compute(), expected[:, 0])
+    def test_serial(self, tmp_path):
+        expected, data = self.generate(tmp_path)
+        result = loads(dumps(data))
+        assert np.array_equal(result.compute(), expected)
+        sliced = result[:, 0]
+        assert np.array_equal(sliced.compute(), expected[:, 0])

--- a/tests/io/test_miniseed.py
+++ b/tests/io/test_miniseed.py
@@ -56,7 +56,7 @@ def test_miniseed(tmp_path):
     paths = sorted(tmp_path.glob("*.mseed"))
 
     # read one file
-    da = xd.open_dataarray(paths[0], engine="miniseed")
+    da = xd.open(paths[0], engine="miniseed")
     assert da.shape == (3, 100)
     assert da.dims == ("channel", "time")
     assert da.coords["time"].isinterp()
@@ -68,7 +68,7 @@ def test_miniseed(tmp_path):
     assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
 
     # read one file without the last sample
-    da = xd.open_dataarray(paths[0], engine="miniseed", ignore_last_sample=True)
+    da = xd.open(paths[0], engine="miniseed", ignore_last_sample=True)
     assert da.shape == (3, 99)
     assert da.dims == ("channel", "time")
     assert da.coords["time"].isinterp()
@@ -82,7 +82,7 @@ def test_miniseed(tmp_path):
     # read one file with gaps
     make_network(tmp_path, gap=True, samples=100)
     paths = sorted(tmp_path.glob("*_gap.mseed"))
-    da = xd.open_dataarray(paths[0], engine="miniseed")
+    da = xd.open(paths[0], engine="miniseed")
     assert da.shape == (3, 90)
     assert da.dims == ("channel", "time")
     assert da.coords["time"].isinterp()
@@ -94,7 +94,7 @@ def test_miniseed(tmp_path):
     assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
 
     # read one file with gaps and ignore the last sample
-    da = xd.open_dataarray(paths[0], engine="miniseed", ignore_last_sample=True)
+    da = xd.open(paths[0], engine="miniseed", ignore_last_sample=True)
     assert da.shape == (3, 89)
     assert da.dims == ("channel", "time")
     assert da.coords["time"].isinterp()
@@ -107,7 +107,7 @@ def test_miniseed(tmp_path):
 
     # manually concatenate several files (without gaps)
     paths = sorted(tmp_path.glob("*00.mseed"))
-    objs = [xd.open_dataarray(path, engine="miniseed") for path in paths]
+    objs = [xd.open(path, engine="miniseed") for path in paths]
     da = xd.concatenate(objs, "station")
     assert da.shape == (10, 3, 100)
     assert da.dims == ("station", "channel", "time")
@@ -121,7 +121,7 @@ def test_miniseed(tmp_path):
 
     # manually concatenate several files with gaps
     paths = sorted(tmp_path.glob("*gap.mseed"))
-    objs = [xd.open_dataarray(path, engine="miniseed") for path in paths]
+    objs = [xd.open(path, engine="miniseed") for path in paths]
     da = xd.concatenate(objs, "station")
     assert da.shape == (10, 3, 90)
     assert da.dims == ("station", "channel", "time")
@@ -134,7 +134,7 @@ def test_miniseed(tmp_path):
     assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
 
     # automatically open multiple files (without gaps)
-    da = xd.open_mfdataarray(tmp_path / "*00.mseed", dim="station", engine="miniseed")
+    da = xd.open(tmp_path / "*00.mseed", dim="station", engine="miniseed")
     assert da.shape == (10, 3, 100)
     assert da.dims == ("station", "channel", "time")
     assert da.coords["station"].values.tolist() == [f"CH{i:03d}" for i in range(1, 11)]
@@ -146,7 +146,7 @@ def test_miniseed(tmp_path):
     assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
 
     # automatically open multiple files (with gaps)
-    da = xd.open_mfdataarray(tmp_path / "*gap.mseed", dim="station", engine="miniseed")
+    da = xd.open(tmp_path / "*gap.mseed", dim="station", engine="miniseed")
     assert da.shape == (10, 3, 90)
     assert da.dims == ("station", "channel", "time")
     assert da.coords["station"].values.tolist() == [f"CH{i:03d}" for i in range(1, 11)]

--- a/tests/io/test_miniseed.py
+++ b/tests/io/test_miniseed.py
@@ -1,6 +1,3 @@
-from glob import glob
-from tempfile import TemporaryDirectory
-
 import numpy as np
 import obspy
 
@@ -54,121 +51,108 @@ def make_header(idx, component, starttime):
     return header
 
 
-def test_miniseed():
-    with TemporaryDirectory() as dirpath:
-        make_network(dirpath, samples=100)
-        paths = sorted(glob(f"{dirpath}/*.mseed"))
+def test_miniseed(tmp_path):
+    make_network(tmp_path, samples=100)
+    paths = sorted(tmp_path.glob("*.mseed"))
 
-        # read one file
-        da = xd.open_dataarray(paths[0], engine="miniseed")
-        assert da.shape == (3, 100)
-        assert da.dims == ("channel", "time")
-        assert da.coords["time"].isinterp()
-        assert da.coords["time"][0].values == np.datetime64("1970-01-01T00:00:00")
-        assert da.coords["time"][-1].values == np.datetime64("1970-01-01T00:00:00.990")
-        assert da.coords["network"].values == "DX"
-        assert da.coords["station"].values == "CH001"
-        assert da.coords["location"].values == "00"
-        assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
+    # read one file
+    da = xd.open_dataarray(paths[0], engine="miniseed")
+    assert da.shape == (3, 100)
+    assert da.dims == ("channel", "time")
+    assert da.coords["time"].isinterp()
+    assert da.coords["time"][0].values == np.datetime64("1970-01-01T00:00:00")
+    assert da.coords["time"][-1].values == np.datetime64("1970-01-01T00:00:00.990")
+    assert da.coords["network"].values == "DX"
+    assert da.coords["station"].values == "CH001"
+    assert da.coords["location"].values == "00"
+    assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
 
-        # read one file without the last sample
-        da = xd.open_dataarray(paths[0], engine="miniseed", ignore_last_sample=True)
-        assert da.shape == (3, 99)
-        assert da.dims == ("channel", "time")
-        assert da.coords["time"].isinterp()
-        assert da.coords["time"][0].values == np.datetime64("1970-01-01T00:00:00")
-        assert da.coords["time"][-1].values == np.datetime64("1970-01-01T00:00:00.980")
-        assert da.coords["network"].values == "DX"
-        assert da.coords["station"].values == "CH001"
-        assert da.coords["location"].values == "00"
-        assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
+    # read one file without the last sample
+    da = xd.open_dataarray(paths[0], engine="miniseed", ignore_last_sample=True)
+    assert da.shape == (3, 99)
+    assert da.dims == ("channel", "time")
+    assert da.coords["time"].isinterp()
+    assert da.coords["time"][0].values == np.datetime64("1970-01-01T00:00:00")
+    assert da.coords["time"][-1].values == np.datetime64("1970-01-01T00:00:00.980")
+    assert da.coords["network"].values == "DX"
+    assert da.coords["station"].values == "CH001"
+    assert da.coords["location"].values == "00"
+    assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
 
-        # read one file with gaps
-        make_network(dirpath, gap=True, samples=100)
-        paths = sorted(glob(f"{dirpath}/*_gap.mseed"))
-        da = xd.open_dataarray(paths[0], engine="miniseed")
-        assert da.shape == (3, 90)
-        assert da.dims == ("channel", "time")
-        assert da.coords["time"].isinterp()
-        assert da.coords["time"][0].values == np.datetime64("1970-01-01T00:00:00")
-        assert da.coords["time"][-1].values == np.datetime64("1970-01-01T00:01:00.390")
-        assert da.coords["network"].values == "DX"
-        assert da.coords["station"].values == "CH001"
-        assert da.coords["location"].values == "00"
-        assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
+    # read one file with gaps
+    make_network(tmp_path, gap=True, samples=100)
+    paths = sorted(tmp_path.glob("*_gap.mseed"))
+    da = xd.open_dataarray(paths[0], engine="miniseed")
+    assert da.shape == (3, 90)
+    assert da.dims == ("channel", "time")
+    assert da.coords["time"].isinterp()
+    assert da.coords["time"][0].values == np.datetime64("1970-01-01T00:00:00")
+    assert da.coords["time"][-1].values == np.datetime64("1970-01-01T00:01:00.390")
+    assert da.coords["network"].values == "DX"
+    assert da.coords["station"].values == "CH001"
+    assert da.coords["location"].values == "00"
+    assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
 
-        # read one file with gaps and ignore the last sample
-        da = xd.open_dataarray(paths[0], engine="miniseed", ignore_last_sample=True)
-        assert da.shape == (3, 89)
-        assert da.dims == ("channel", "time")
-        assert da.coords["time"].isinterp()
-        assert da.coords["time"][0].values == np.datetime64("1970-01-01T00:00:00")
-        assert da.coords["time"][-1].values == np.datetime64("1970-01-01T00:01:00.380")
-        assert da.coords["network"].values == "DX"
-        assert da.coords["station"].values == "CH001"
-        assert da.coords["location"].values == "00"
-        assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
+    # read one file with gaps and ignore the last sample
+    da = xd.open_dataarray(paths[0], engine="miniseed", ignore_last_sample=True)
+    assert da.shape == (3, 89)
+    assert da.dims == ("channel", "time")
+    assert da.coords["time"].isinterp()
+    assert da.coords["time"][0].values == np.datetime64("1970-01-01T00:00:00")
+    assert da.coords["time"][-1].values == np.datetime64("1970-01-01T00:01:00.380")
+    assert da.coords["network"].values == "DX"
+    assert da.coords["station"].values == "CH001"
+    assert da.coords["location"].values == "00"
+    assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
 
-        # manually concatenate several files (without gaps)
-        paths = sorted(glob(f"{dirpath}/*00.mseed"))
-        objs = [xd.open_dataarray(path, engine="miniseed") for path in paths]
-        da = xd.concatenate(objs, "station")
-        assert da.shape == (10, 3, 100)
-        assert da.dims == ("station", "channel", "time")
-        assert da.coords["station"].values.tolist() == [
-            f"CH{i:03d}" for i in range(1, 11)
-        ]
-        assert da.coords["time"].isinterp()
-        assert da.coords["time"][0].values == np.datetime64("1970-01-01T00:00:00")
-        assert da.coords["time"][-1].values == np.datetime64("1970-01-01T00:00:00.990")
-        assert da.coords["network"].values == "DX"
-        assert da.coords["location"].values == "00"
-        assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
+    # manually concatenate several files (without gaps)
+    paths = sorted(tmp_path.glob("*00.mseed"))
+    objs = [xd.open_dataarray(path, engine="miniseed") for path in paths]
+    da = xd.concatenate(objs, "station")
+    assert da.shape == (10, 3, 100)
+    assert da.dims == ("station", "channel", "time")
+    assert da.coords["station"].values.tolist() == [f"CH{i:03d}" for i in range(1, 11)]
+    assert da.coords["time"].isinterp()
+    assert da.coords["time"][0].values == np.datetime64("1970-01-01T00:00:00")
+    assert da.coords["time"][-1].values == np.datetime64("1970-01-01T00:00:00.990")
+    assert da.coords["network"].values == "DX"
+    assert da.coords["location"].values == "00"
+    assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
 
-        # manually concatenate several files with gaps
-        paths = sorted(glob(f"{dirpath}/*gap.mseed"))
-        objs = [xd.open_dataarray(path, engine="miniseed") for path in paths]
-        da = xd.concatenate(objs, "station")
-        assert da.shape == (10, 3, 90)
-        assert da.dims == ("station", "channel", "time")
-        assert da.coords["station"].values.tolist() == [
-            f"CH{i:03d}" for i in range(1, 11)
-        ]
-        assert da.coords["time"].isinterp()
-        assert da.coords["time"][0].values == np.datetime64("1970-01-01T00:00:00")
-        assert da.coords["time"][-1].values == np.datetime64("1970-01-01T00:01:00.390")
-        assert da.coords["network"].values == "DX"
-        assert da.coords["location"].values == "00"
-        assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
+    # manually concatenate several files with gaps
+    paths = sorted(tmp_path.glob("*gap.mseed"))
+    objs = [xd.open_dataarray(path, engine="miniseed") for path in paths]
+    da = xd.concatenate(objs, "station")
+    assert da.shape == (10, 3, 90)
+    assert da.dims == ("station", "channel", "time")
+    assert da.coords["station"].values.tolist() == [f"CH{i:03d}" for i in range(1, 11)]
+    assert da.coords["time"].isinterp()
+    assert da.coords["time"][0].values == np.datetime64("1970-01-01T00:00:00")
+    assert da.coords["time"][-1].values == np.datetime64("1970-01-01T00:01:00.390")
+    assert da.coords["network"].values == "DX"
+    assert da.coords["location"].values == "00"
+    assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
 
-        # automatically open multiple files (without gaps)
-        da = xd.open_mfdataarray(
-            f"{dirpath}/*00.mseed", dim="station", engine="miniseed"
-        )
-        assert da.shape == (10, 3, 100)
-        assert da.dims == ("station", "channel", "time")
-        assert da.coords["station"].values.tolist() == [
-            f"CH{i:03d}" for i in range(1, 11)
-        ]
-        assert da.coords["time"].isinterp()
-        assert da.coords["time"][0].values == np.datetime64("1970-01-01T00:00:00")
-        assert da.coords["time"][-1].values == np.datetime64("1970-01-01T00:00:00.990")
-        assert da.coords["network"].values == "DX"
-        assert da.coords["location"].values == "00"
-        assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
+    # automatically open multiple files (without gaps)
+    da = xd.open_mfdataarray(tmp_path / "*00.mseed", dim="station", engine="miniseed")
+    assert da.shape == (10, 3, 100)
+    assert da.dims == ("station", "channel", "time")
+    assert da.coords["station"].values.tolist() == [f"CH{i:03d}" for i in range(1, 11)]
+    assert da.coords["time"].isinterp()
+    assert da.coords["time"][0].values == np.datetime64("1970-01-01T00:00:00")
+    assert da.coords["time"][-1].values == np.datetime64("1970-01-01T00:00:00.990")
+    assert da.coords["network"].values == "DX"
+    assert da.coords["location"].values == "00"
+    assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
 
-        # automatically open multiple files (with gaps)
-        da = xd.open_mfdataarray(
-            f"{dirpath}/*gap.mseed", dim="station", engine="miniseed"
-        )
-        assert da.shape == (10, 3, 90)
-        assert da.dims == ("station", "channel", "time")
-        assert da.coords["station"].values.tolist() == [
-            f"CH{i:03d}" for i in range(1, 11)
-        ]
-        assert da.coords["time"].isinterp()
-        assert da.coords["time"][0].values == np.datetime64("1970-01-01T00:00:00")
-        assert da.coords["time"][-1].values == np.datetime64("1970-01-01T00:01:00.390")
-        assert da.coords["network"].values == "DX"
-        assert da.coords["location"].values == "00"
-        assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]
+    # automatically open multiple files (with gaps)
+    da = xd.open_mfdataarray(tmp_path / "*gap.mseed", dim="station", engine="miniseed")
+    assert da.shape == (10, 3, 90)
+    assert da.dims == ("station", "channel", "time")
+    assert da.coords["station"].values.tolist() == [f"CH{i:03d}" for i in range(1, 11)]
+    assert da.coords["time"].isinterp()
+    assert da.coords["time"][0].values == np.datetime64("1970-01-01T00:00:00")
+    assert da.coords["time"][-1].values == np.datetime64("1970-01-01T00:01:00.390")
+    assert da.coords["network"].values == "DX"
+    assert da.coords["location"].values == "00"
+    assert da.coords["channel"].values.tolist() == ["HHZ", "HHN", "HHE"]

--- a/tests/test_atoms.py
+++ b/tests/test_atoms.py
@@ -1,5 +1,4 @@
 import pickle
-import tempfile
 
 import numpy as np
 import scipy.signal as sp
@@ -32,14 +31,13 @@ class TestPartialAtom:
             ]
         )
 
-    def test_pickable(self):
+    def test_pickable(self, tmp_path):
         atom = xs.integrate(..., dim="dim")
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tmpfile_path = f"{tmpdir}/tempfile.pkl"
-            with open(tmpfile_path, "wb") as tmpfile:
-                pickle.dump(atom, tmpfile)
-            with open(tmpfile_path, "rb") as tmpfile:
-                result = pickle.load(tmpfile)
+        tmpfile_path = tmp_path / "tempfile.pkl"
+        with open(tmpfile_path, "wb") as tmpfile:
+            pickle.dump(atom, tmpfile)
+        with open(tmpfile_path, "rb") as tmpfile:
+            result = pickle.load(tmpfile)
         assert result.func.__module__ == atom.func.__module__
         assert result.func.__name__ == atom.func.__name__
         assert result.args == atom.args

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,3 @@
-import os
-from tempfile import TemporaryDirectory
-
 import numpy as np
 import pytest
 
@@ -31,73 +28,66 @@ class TestCore:
 
     def test_open_mfdatacollection(self): ...  # TODO
 
-    def test_open_mfdatatree(self):
-        with TemporaryDirectory() as dirpath:
-            keys = ["LOC01", "LOC02"]
-            dirnames = [os.path.join(dirpath, key) for key in keys]
-            for dirname in dirnames:
-                os.mkdir(dirname)
-                for idx, da in enumerate(wavelet_wavefronts(nchunk=3), start=1):
-                    da.to_netcdf(os.path.join(dirname, f"{idx:03d}.nc"))
-            da = wavelet_wavefronts()
-            dc = xd.open_mfdatatree(
-                os.path.join(dirpath, "{node}", "00[acquisition].nc")
-            )
-            assert list(dc.keys()) == keys
-            for key in keys:
-                assert dc[key][0].load().equals(da)
-
-    def test_open_mfdataarray(self):
-        with TemporaryDirectory() as dirpath:
-            wavelet_wavefronts().to_netcdf(os.path.join(dirpath, "sample.nc"))
+    def test_open_mfdatatree(self, tmp_path):
+        keys = ["LOC01", "LOC02"]
+        dirnames = [tmp_path / key for key in keys]
+        for dirname in dirnames:
+            dirname.mkdir()
             for idx, da in enumerate(wavelet_wavefronts(nchunk=3), start=1):
-                da.to_netcdf(os.path.join(dirpath, f"{idx:03}.nc"))
-            da_monolithic = xd.open_dataarray(os.path.join(dirpath, "sample.nc"))
-            da_chunked = xd.open_mfdataarray(os.path.join(dirpath, "00*.nc"))
-            assert da_monolithic.equals(da_chunked)
-            da_chunked = xd.open_mfdataarray(
-                [
-                    os.path.join(dirpath, fname)
-                    for fname in ["001.nc", "002.nc", "003.nc"]
-                ]
-            )
-            assert da_monolithic.equals(da_chunked)
-        with pytest.raises(FileNotFoundError):
-            xd.open_mfdataarray("not_existing_files_*.nc")
-        with pytest.raises(FileNotFoundError):
-            xd.open_mfdataarray(["not_existing_file.nc"])
+                da.to_netcdf(dirname / f"{idx:03d}.nc")
+        da = wavelet_wavefronts()
+        dc = xd.open_mfdatatree(tmp_path / "{node}" / "00[acquisition].nc")
+        assert list(dc.keys()) == keys
+        for key in keys:
+            assert dc[key][0].load().equals(da)
 
-    def test_open_mfdataarray_grouping(self):
-        with TemporaryDirectory() as dirpath:
-            acqs = [
-                {
-                    "starttime": "2023-01-01T00:00:00",
-                    "resolution": (np.timedelta64(20, "ms"), 20.0),
-                    "nchunk": 10,
-                },
-                {
-                    "starttime": "2023-01-01T06:00:00",
-                    "resolution": (np.timedelta64(10, "ms"), 20.0),
-                    "nchunk": 10,
-                },
-                {
-                    "starttime": "2023-01-01T12:00:00",
-                    "resolution": (np.timedelta64(10, "ms"), 10.0),
-                    "nchunk": 10,
-                },
-            ]
-            count = 1
-            for acq in acqs:
-                for da in wavelet_wavefronts(**acq):
-                    da.to_netcdf(os.path.join(dirpath, f"{count:03d}.nc"))
-                    count += 1
-            dc = xd.open_mfdataarray(os.path.join(dirpath, "*.nc"))
-            assert len(dc) == 3
-            for da, acq in zip(dc, acqs):
-                acq |= {"nchunk": None}
-                assert da.equals(wavelet_wavefronts(**acq))
+    def test_open_mfdataarray(self, tmp_path):
+        wavelet_wavefronts().to_netcdf(tmp_path / "sample.nc")
+        for idx, da in enumerate(wavelet_wavefronts(nchunk=3), start=1):
+            da.to_netcdf(tmp_path / f"{idx:03}.nc")
+        da_monolithic = xd.open_dataarray(tmp_path / "sample.nc")
+        da_chunked = xd.open_mfdataarray(tmp_path / "00*.nc")
+        assert da_monolithic.equals(da_chunked)
+        da_chunked = xd.open_mfdataarray(
+            [tmp_path / fname for fname in ["001.nc", "002.nc", "003.nc"]]
+        )
+        assert da_monolithic.equals(da_chunked)
 
-    def test_concatenate(self):
+    with pytest.raises(FileNotFoundError):
+        xd.open_mfdataarray("not_existing_files_*.nc")
+    with pytest.raises(FileNotFoundError):
+        xd.open_mfdataarray(["not_existing_file.nc"])
+
+    def test_open_mfdataarray_grouping(self, tmp_path):
+        acqs = [
+            {
+                "starttime": "2023-01-01T00:00:00",
+                "resolution": (np.timedelta64(20, "ms"), 20.0),
+                "nchunk": 10,
+            },
+            {
+                "starttime": "2023-01-01T06:00:00",
+                "resolution": (np.timedelta64(10, "ms"), 20.0),
+                "nchunk": 10,
+            },
+            {
+                "starttime": "2023-01-01T12:00:00",
+                "resolution": (np.timedelta64(10, "ms"), 10.0),
+                "nchunk": 10,
+            },
+        ]
+        count = 1
+        for acq in acqs:
+            for da in wavelet_wavefronts(**acq):
+                da.to_netcdf(tmp_path / f"{count:03d}.nc")
+                count += 1
+        dc = xd.open_mfdataarray(tmp_path / "*.nc")
+        assert len(dc) == 3
+        for da, acq in zip(dc, acqs):
+            acq |= {"nchunk": None}
+            assert da.equals(wavelet_wavefronts(**acq))
+
+    def test_concatenate(self, tmp_path):
         # concatenate two data arrays
         da1 = wavelet_wavefronts(starttime="2023-01-01T00:00:00")
         da2 = wavelet_wavefronts(starttime="2023-01-01T00:00:06")
@@ -116,19 +106,18 @@ class TestCore:
         result = xd.concatenate([da1, da2.isel(time=slice(0, 0))])
         assert result.equals(da1)
         # concat of sources and stacks
-        with TemporaryDirectory() as tmp_path:
-            da1.to_netcdf(os.path.join(tmp_path, "da1.nc"))
-            da2.to_netcdf(os.path.join(tmp_path, "da2.nc"))
-            da1 = xd.open_dataarray(os.path.join(tmp_path, "da1.nc"))
-            da2 = xd.open_dataarray(os.path.join(tmp_path, "da2.nc"))
-            result = xd.concatenate([da1, da2])
-            assert isinstance(result.data, VirtualStack)
-            assert result.equals(expected)
-            da1.data = VirtualStack([da1.data])
-            da2.data = VirtualStack([da2.data])
-            result = xd.concatenate([da1, da2])
-            assert isinstance(result.data, VirtualStack)
-            assert result.equals(expected)
+        da1.to_netcdf(tmp_path / "da1.nc")
+        da2.to_netcdf(tmp_path / "da2.nc")
+        da1 = xd.open_dataarray(tmp_path / "da1.nc")
+        da2 = xd.open_dataarray(tmp_path / "da2.nc")
+        result = xd.concatenate([da1, da2])
+        assert isinstance(result.data, VirtualStack)
+        assert result.equals(expected)
+        da1.data = VirtualStack([da1.data])
+        da2.data = VirtualStack([da2.data])
+        result = xd.concatenate([da1, da2])
+        assert isinstance(result.data, VirtualStack)
+        assert result.equals(expected)
         # concat of 3D data arrays with unsorted coords:
         da1 = xd.DataArray(
             data=np.zeros((5, 4, 3)),

--- a/tests/test_dataarray.py
+++ b/tests/test_dataarray.py
@@ -1,7 +1,3 @@
-import os
-from glob import glob
-from tempfile import TemporaryDirectory
-
 import dask
 import hdf5plugin
 import numpy as np
@@ -306,7 +302,7 @@ class TestDataArray:
         assert np.array_equal(result["relative_time"], [0, 1, 2])
         assert result.dims == da.dims
 
-    def test_netcdf_non_dimensional(self):
+    def test_netcdf_non_dimensional(self, tmp_path):
         da = xd.DataArray(
             data=np.zeros(3),
             coords={
@@ -314,20 +310,19 @@ class TestDataArray:
                 "relative_time": ("time", np.array([0, 1, 2])),
             },
         )
-        with TemporaryDirectory() as dirpath:
-            path = os.path.join(dirpath, "tmp.nc")
-            da.to_netcdf(path)
-            result = xd.open_dataarray(path)
-            assert result.equals(da)
-        with TemporaryDirectory() as dirpath:
-            path = os.path.join(dirpath, "da.nc")
-            da = wavelet_wavefronts().assign_coords(lon=("distance", np.arange(401)))
-            da.to_netcdf(path)
-            tmp = xd.open_dataarray(path)
-            path = path = os.path.join(dirpath, "vds.nc")
-            tmp.to_netcdf(path)
-            result = xd.open_dataarray(path)
-            assert result.equals(da)
+        path = tmp_path / "tmp.nc"
+        da.to_netcdf(path)
+        result = xd.open_dataarray(path)
+        assert result.equals(da)
+
+        da_path = tmp_path / "da.nc"
+        da = wavelet_wavefronts().assign_coords(lon=("distance", np.arange(401)))
+        da.to_netcdf(da_path)
+        tmp = xd.open_dataarray(da_path)
+        vds_path = tmp_path / "vds.nc"
+        tmp.to_netcdf(vds_path)
+        result = xd.open_dataarray(vds_path)
+        assert result.equals(da)
 
     def test_transpose(self):
         da = wavelet_wavefronts()
@@ -355,118 +350,110 @@ class TestDataArray:
         assert result.shape == (1, 3)
         assert result["y"].equals(xd.Coordinate([0], dim="y"))
 
-    def test_io(self):
+    def test_io(self, tmp_path):
         # both coords interpolated
         da = wavelet_wavefronts()
-        with TemporaryDirectory() as dirpath:
-            path = os.path.join(dirpath, "tmp.nc")
-            da.to_netcdf(path)
-            da_recovered = xd.DataArray.from_netcdf(path)
-            assert da.equals(da_recovered)
+        path = tmp_path / "interp.nc"
+        da.to_netcdf(path)
+        da_recovered = xd.DataArray.from_netcdf(path)
+        assert da.equals(da_recovered)
 
         # mixed interpolated and dense
         da["time"] = np.asarray(da["time"])
-        with TemporaryDirectory() as dirpath:
-            path = os.path.join(dirpath, "tmp.nc")
-            da.to_netcdf(path)
-            da_recovered = xd.DataArray.from_netcdf(path)
-            assert da.equals(da_recovered)
+        path = tmp_path / "mixed.nc"
+        da.to_netcdf(path)
+        da_recovered = xd.DataArray.from_netcdf(path)
+        assert da.equals(da_recovered)
 
         # only dense coords
         da["distance"] = np.asarray(da["distance"])
-        with TemporaryDirectory() as dirpath:
-            path = os.path.join(dirpath, "tmp.nc")
-            da.to_netcdf(path)
-            da_recovered = xd.DataArray.from_netcdf(path)
-            assert da.equals(da_recovered)
+        path = tmp_path / "dense.nc"
+        da.to_netcdf(path)
+        da_recovered = xd.DataArray.from_netcdf(path)
+        assert da.equals(da_recovered)
 
-    def test_io_with_zfp_compression(self):
+    def test_io_with_zfp_compression(self, tmp_path):
         da = xd.DataArray(np.random.rand(101, 101))
-        with TemporaryDirectory() as tmpdir:
-            tmpfile_uncompressed = os.path.join(tmpdir, "uncompressed.nc")
-            da.to_netcdf(tmpfile_uncompressed)
-            tmpfile_compressed = os.path.join(tmpdir, "compressed.nc")
-            da.to_netcdf(tmpfile_compressed, encoding=hdf5plugin.Zfp(accuracy=0.001))
-            tmpfile_chunk_compressed = os.path.join(tmpdir, "chunk_compressed.nc")
-            da.to_netcdf(
-                tmpfile_chunk_compressed,
-                encoding={"chunks": (10, 10), **hdf5plugin.Zfp(accuracy=0.001)},
-            )
-            uncompressed_size = os.path.getsize(tmpfile_uncompressed)
-            compressed_size = os.path.getsize(tmpfile_compressed)
-            chunk_compressed_size = os.path.getsize(tmpfile_chunk_compressed)
-            assert chunk_compressed_size < uncompressed_size
-            assert compressed_size < chunk_compressed_size
-            _da = xd.DataArray.from_netcdf(tmpfile_compressed)
-            assert np.abs(da - _da).max().values < 0.001
+        tmpfile_uncompressed = tmp_path / "uncompressed.nc"
+        da.to_netcdf(tmpfile_uncompressed)
+        tmpfile_compressed = tmp_path / "compressed.nc"
+        da.to_netcdf(tmpfile_compressed, encoding=hdf5plugin.Zfp(accuracy=0.001))
+        tmpfile_chunk_compressed = tmp_path / "chunk_compressed.nc"
+        da.to_netcdf(
+            tmpfile_chunk_compressed,
+            encoding={"chunks": (10, 10), **hdf5plugin.Zfp(accuracy=0.001)},
+        )
+        uncompressed_size = tmpfile_uncompressed.stat().st_size
+        compressed_size = tmpfile_compressed.stat().st_size
+        chunk_compressed_size = tmpfile_chunk_compressed.stat().st_size
+        assert chunk_compressed_size < uncompressed_size
+        assert compressed_size < chunk_compressed_size
+        _da = xd.DataArray.from_netcdf(tmpfile_compressed)
+        assert np.abs(da - _da).max().values < 0.001
 
-    def test_io_dask(self):
-        with TemporaryDirectory() as tmpdir:
-            values = np.random.rand(3, 10)
-            chunks = np.split(values, 5, axis=1)
-            for idx, chunk in enumerate(chunks):
-                np.save(os.path.join(tmpdir, f"chunk_{idx}.npy"), chunk)
-            paths = glob(os.path.join(tmpdir, "*.npy"))
-            chunks = [dask.delayed(np.load)(path) for path in paths]
-            chunks = [
-                dask.array.from_delayed(chunk, shape=(3, 2), dtype=values.dtype)
-                for chunk in chunks
-            ]
-            data = dask.array.concatenate(chunks, axis=1)
-            expected = xd.DataArray(
-                data,
-                coords={"time": np.arange(3), "distance": np.arange(10)},
-                attrs={"version": "1.0"},
-                name="data",
-            )
-            fname = os.path.join(tmpdir, "tmp.nc")
-            expected.to_netcdf(fname)
-            result = xd.open_dataarray(fname)
-            assert isinstance(result.data, dask.array.Array)
-            assert np.array_equal(expected.values, result.values)
-            assert expected.dtype == result.dtype
-            assert expected.coords.equals(result.coords)
-            assert expected.dims == result.dims
-            assert expected.name == result.name
-            assert expected.attrs == result.attrs
+    def test_io_dask(self, tmp_path):
+        values = np.random.rand(3, 10)
+        chunks = np.split(values, 5, axis=1)
+        for idx, chunk in enumerate(chunks):
+            np.save(tmp_path / f"chunk_{idx}.npy", chunk)
+        paths = sorted(tmp_path.glob("*.npy"))
+        chunks = [dask.delayed(np.load)(str(path)) for path in paths]
+        chunks = [
+            dask.array.from_delayed(chunk, shape=(3, 2), dtype=values.dtype)
+            for chunk in chunks
+        ]
+        data = dask.array.concatenate(chunks, axis=1)
+        expected = xd.DataArray(
+            data,
+            coords={"time": np.arange(3), "distance": np.arange(10)},
+            attrs={"version": "1.0"},
+            name="data",
+        )
+        fname = tmp_path / "tmp.nc"
+        expected.to_netcdf(fname)
+        result = xd.open_dataarray(fname)
+        assert isinstance(result.data, dask.array.Array)
+        assert np.array_equal(expected.values, result.values)
+        assert expected.dtype == result.dtype
+        assert expected.coords.equals(result.coords)
+        assert expected.dims == result.dims
+        assert expected.name == result.name
+        assert expected.attrs == result.attrs
 
-    def test_io_non_dimensional(self):
+    def test_io_non_dimensional(self, tmp_path):
         expected = xd.DataArray(coords={"dim": 0}, dims=())
-        with TemporaryDirectory() as dirpath:
-            path = os.path.join(dirpath, "tmp.nc")
-            expected.to_netcdf(path)
-            result = xd.DataArray.from_netcdf(path)
-            assert expected.equals(result)
+        path = tmp_path / "tmp.nc"
+        expected.to_netcdf(path)
+        result = xd.DataArray.from_netcdf(path)
+        assert expected.equals(result)
 
-    def test_io_attrs(self):
+    def test_io_attrs(self, tmp_path):
         attrs = {"description": "test"}
         da = xd.DataArray(
             np.arange(3),
             coords={"time": np.array([3, 4, 5])},
             attrs=attrs,
         )
-        with TemporaryDirectory() as dirpath:
-            path = os.path.join(dirpath, "tmp.nc")
-            da.to_netcdf(path)
-            result = xd.DataArray.from_netcdf(path)
-            assert result.attrs == attrs
-            assert result.equals(da)
-            da = xd.open_dataarray(path)
-            path = os.path.join(dirpath, "vds.nc")
-            da.to_netcdf(path)
-            result = xd.open_dataarray(path)
-            assert result.attrs == attrs
-            assert result.equals(da)
+        path = tmp_path / "tmp.nc"
+        da.to_netcdf(path)
+        result = xd.DataArray.from_netcdf(path)
+        assert result.attrs == attrs
+        assert result.equals(da)
+        da = xd.open_dataarray(path)
+        path = tmp_path / "vds.nc"
+        da.to_netcdf(path)
+        result = xd.open_dataarray(path)
+        assert result.attrs == attrs
+        assert result.equals(da)
 
-    def test_io_create_dirs(self):
+    def test_io_create_dirs(self, tmp_path):
         da = xd.DataArray(np.arange(3))
-        with TemporaryDirectory() as dirpath:
-            path = os.path.join(dirpath, "subdir", "tmp.nc")
-            with pytest.raises(FileNotFoundError, match="No such file or directory"):
-                da.to_netcdf(path)
-            da.to_netcdf(path, create_dirs=True)
-            result = xd.DataArray.from_netcdf(path)
-            assert result.equals(da)
+        path = tmp_path / "subdir" / "tmp.nc"
+        with pytest.raises(FileNotFoundError, match="No such file or directory"):
+            da.to_netcdf(path)
+        da.to_netcdf(path, create_dirs=True)
+        result = xd.DataArray.from_netcdf(path)
+        assert result.equals(da)
 
     def test_ufunc(self):
         da = wavelet_wavefronts()

--- a/tests/test_datacollection.py
+++ b/tests/test_datacollection.py
@@ -1,6 +1,3 @@
-import os
-from tempfile import TemporaryDirectory
-
 import h5py
 import pytest
 
@@ -33,7 +30,7 @@ class TestDataCollection:
         result = xd.DataCollection(data)
         assert result.equals(dc)
 
-    def test_io(self):
+    def test_io(self, tmp_path):
         da = wavelet_wavefronts()
         dc = xd.DataCollection(
             {
@@ -42,17 +39,15 @@ class TestDataCollection:
             },
             "instrument",
         )
-        with TemporaryDirectory() as dirpath:
-            path = os.path.join(dirpath, "tmp.nc")
-            dc.to_netcdf(path)
-            result = xd.DataCollection.from_netcdf(path)
-            assert result.equals(dc)
+        path = tmp_path / "tmp1.nc"
+        dc.to_netcdf(path)
+        result = xd.DataCollection.from_netcdf(path)
+        assert result.equals(dc)
         dc = xd.DataCollection([da, da], "instrument")
-        with TemporaryDirectory() as dirpath:
-            path = os.path.join(dirpath, "tmp.nc")
-            dc.to_netcdf(path)
-            result = xd.DataCollection.from_netcdf(path)
-            assert result.equals(dc)
+        path = tmp_path / "tmp2.nc"
+        dc.to_netcdf(path)
+        result = xd.DataCollection.from_netcdf(path)
+        assert result.equals(dc)
         dc = xd.DataCollection(
             {
                 "das1": xd.DataCollection([da, da], "acquisition"),
@@ -60,15 +55,14 @@ class TestDataCollection:
             },
             "instrument",
         )
-        with TemporaryDirectory() as dirpath:
-            path = os.path.join(dirpath, "tmp.nc")
-            dc.to_netcdf(path)
-            result = xd.DataCollection.from_netcdf(path)
-            assert result.equals(dc)
-            result = xd.open_datacollection(path)
-            assert result.equals(dc)
+        path = tmp_path / "tmp3.nc"
+        dc.to_netcdf(path)
+        result = xd.DataCollection.from_netcdf(path)
+        assert result.equals(dc)
+        result = xd.open_datacollection(path)
+        assert result.equals(dc)
 
-    def test_io_create_dirs(self):
+    def test_io_create_dirs(self, tmp_path):
         da = wavelet_wavefronts()
         dc = xd.DataCollection(
             {
@@ -77,29 +71,27 @@ class TestDataCollection:
             },
             "instrument",
         )
-        with TemporaryDirectory() as dirpath:
-            path = os.path.join(dirpath, "subdir", "tmp.nc")
-            with pytest.raises(FileNotFoundError, match="No such file or directory"):
-                dc.to_netcdf(path)
-            dc.to_netcdf(path, create_dirs=True)
-            result = xd.DataCollection.from_netcdf(path)
-            assert result.equals(dc)
+        path = tmp_path / "subdir" / "tmp.nc"
+        with pytest.raises(FileNotFoundError, match="No such file or directory"):
+            dc.to_netcdf(path)
+        dc.to_netcdf(path, create_dirs=True)
+        result = xd.DataCollection.from_netcdf(path)
+        assert result.equals(dc)
 
-    def test_depth_counter(self):
+    def test_depth_counter(self, tmp_path):
         da = wavelet_wavefronts()
         da.name = "da"
         dc = self.nest(da)
-        with TemporaryDirectory() as dirpath:
-            path = os.path.join(dirpath, "tmp.nc")
-            dc.to_netcdf(path)
-            with h5py.File(path) as file:
-                assert get_depth(file) > 0
-                assert get_depth(file["instrument"]) > 0
-                assert get_depth(file["instrument/das1"]) > 0
-                assert get_depth(file["instrument/das1/acquisition"]) > 0
-                assert get_depth(file["instrument/das1/acquisition/0"]) == 0
-                with pytest.raises(ValueError):
-                    get_depth(file["instrument/das1/acquisition/0/da"]) == 0
+        path = tmp_path / "tmp.nc"
+        dc.to_netcdf(path)
+        with h5py.File(path) as file:
+            assert get_depth(file) > 0
+            assert get_depth(file["instrument"]) > 0
+            assert get_depth(file["instrument/das1"]) > 0
+            assert get_depth(file["instrument/das1/acquisition"]) > 0
+            assert get_depth(file["instrument/das1/acquisition/0"]) == 0
+            with pytest.raises(ValueError):
+                get_depth(file["instrument/das1/acquisition/0/da"]) == 0
 
     def test_isel(self):
         da = wavelet_wavefronts()

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,8 +1,6 @@
-import os
-import tempfile
 import threading
 import time
-from glob import glob
+from pathlib import Path
 
 import hdf5plugin
 import numpy as np
@@ -27,149 +25,143 @@ from xdas.synthetics import wavelet_wavefronts
 
 
 class TestProcessing:
-    def test_stateful(self):
-        with tempfile.TemporaryDirectory() as tempdir:
-            # generate test dataarray
-            wavelet_wavefronts().to_netcdf(os.path.join(tempdir, "sample.nc"))
-            da = xd.open_dataarray(os.path.join(tempdir, "sample.nc"))
+    def test_stateful(self, tmp_path):
+        sample_path = tmp_path / "sample.nc"
 
-            # declare processing sequence
-            sos = sp.iirfilter(4, 0.1, btype="lowpass", output="sos")
-            sequence = Sequential([Partial(sosfilt, sos, ..., dim="time", zi=...)])
+        # generate test dataarray
+        wavelet_wavefronts().to_netcdf(sample_path)
+        da = xd.open_dataarray(sample_path)
 
-            # monolithic processing
-            result1 = sequence(da)
+        # declare processing sequence
+        sos = sp.iirfilter(4, 0.1, btype="lowpass", output="sos")
+        sequence = Sequential([Partial(sosfilt, sos, ..., dim="time", zi=...)])
 
-            # chunked processing
-            data_loader = DataArrayLoader(da, chunks={"time": 100})
-            data_writer = DataArrayWriter(tempdir)
-            result2 = process(
-                sequence, data_loader, data_writer
-            )  # resets the sequence by default
+        # monolithic processing
+        result1 = sequence(da)
 
-            # test
-            assert result1.equals(result2)
+        # chunked processing
+        data_loader = DataArrayLoader(da, chunks={"time": 100})
+        data_writer = DataArrayWriter(tmp_path)
+        result2 = process(
+            sequence, data_loader, data_writer
+        )  # resets the sequence by default
+
+        # test
+        assert result1.equals(result2)
 
 
 class TestDataFrameWriter:
-    def test_write_and_result(self):
-        # Create a temporary directory for test output
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            # Create a DataFrameWriter instance
-            writer = DataFrameWriter(os.path.join(tmp_dir, "output.csv"))
+    def test_write_and_result(self, tmp_path):
+        # Create a DataFrameWriter instance
+        writer = DataFrameWriter(tmp_path / "output.csv")
 
-            # Create a DataFrame to write
-            df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        # Create a DataFrame to write
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
 
-            # Write the DataFrame asynchronously
-            writer.write(df)
+        # Write the DataFrame asynchronously
+        writer.write(df)
 
-            # Get the result (wait for the asynchronous task to complete)
-            result = writer.result()
+        # Get the result (wait for the asynchronous task to complete)
+        result = writer.result()
 
-            # Check if the result matches the original DataFrame
-            assert result.equals(df)
+        # Check if the result matches the original DataFrame
+        assert result.equals(df)
 
-            # Check if the output file exists
-            assert os.path.exists(writer.path)
+        # Check if the output file exists
+        assert Path(writer.path).exists()
 
-            # Check if the output file contains the correct data
-            output_df = pd.read_csv(writer.path)
-            assert output_df.equals(df)
+        # Check if the output file contains the correct data
+        output_df = pd.read_csv(writer.path)
+        assert output_df.equals(df)
 
-    def test_write_multiple_dataframes(self):
-        # Create a temporary directory for test output
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            # Create a DataFrameWriter instance
-            writer = DataFrameWriter(os.path.join(tmp_dir, "output.csv"))
+    def test_write_multiple_dataframes(self, tmp_path):
+        # Create a DataFrameWriter instance
+        writer = DataFrameWriter(tmp_path / "output.csv")
 
-            # Create multiple DataFrames to write
-            df1 = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-            df2 = pd.DataFrame({"A": [7, 8, 9], "B": [10, 11, 12]})
+        # Create multiple DataFrames to write
+        df1 = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        df2 = pd.DataFrame({"A": [7, 8, 9], "B": [10, 11, 12]})
 
-            # Write the DataFrames asynchronously
-            writer.write(df1)
-            writer.write(df2)
+        # Write the DataFrames asynchronously
+        writer.write(df1)
+        writer.write(df2)
 
-            # Get the result (wait for the asynchronous task to complete)
-            result = writer.result()
+        # Get the result (wait for the asynchronous task to complete)
+        result = writer.result()
 
-            # Check if the result matches the concatenated DataFrames
-            expected_result = pd.concat([df1, df2], ignore_index=True)
-            assert result.equals(expected_result)
+        # Check if the result matches the concatenated DataFrames
+        expected_result = pd.concat([df1, df2], ignore_index=True)
+        assert result.equals(expected_result)
 
-            # Check if the output file exists
-            assert os.path.exists(writer.path)
+        # Check if the output file exists
+        assert Path(writer.path).exists()
 
-            # Check if the output file contains the correct data
-            output_df = pd.read_csv(writer.path)
-            assert output_df.equals(expected_result)
+        # Check if the output file contains the correct data
+        output_df = pd.read_csv(writer.path)
+        assert output_df.equals(expected_result)
 
-    def test_write_empty_dataframe(self):
-        # Create a temporary directory for test output
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            # Create a DataFrameWriter instance
-            writer = DataFrameWriter(os.path.join(tmp_dir, "output.csv"))
+    def test_write_empty_dataframe(self, tmp_path):
+        # Create a DataFrameWriter instance
+        writer = DataFrameWriter(tmp_path / "output.csv")
 
-            # Create an empty DataFrame to write
-            df = pd.DataFrame()
+        # Create an empty DataFrame to write
+        df = pd.DataFrame()
 
-            # Write the DataFrame asynchronously
-            writer.write(df)
+        # Write the DataFrame asynchronously
+        writer.write(df)
 
-            # Get the result (wait for the asynchronous task to complete)
-            result = writer.result()
+        # Get the result (wait for the asynchronous task to complete)
+        result = writer.result()
 
-            # Check if the result matches the original DataFrame
-            assert result.equals(df)
+        # Check if the result matches the original DataFrame
+        assert result.equals(df)
 
-            # Check if the output file exists
-            assert os.path.exists(writer.path)
+        # Check if the output file exists
+        assert Path(writer.path).exists()
 
-    def test_write_and_result_with_existing_file(self):
-        # Create a temporary directory for test output
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            # Create a DataFrameWriter instance
-            writer = DataFrameWriter(os.path.join(tmp_dir, "output.csv"))
+    def test_write_and_result_with_existing_file(self, tmp_path):
+        # Create a DataFrameWriter instance
+        output_path = tmp_path / "output.csv"
+        writer = DataFrameWriter(output_path)
 
-            # Create a DataFrame to write
-            df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        # Create a DataFrame to write
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
 
-            # Write the DataFrame asynchronously
-            writer.write(df)
+        # Write the DataFrame asynchronously
+        writer.write(df)
 
-            # Get the result (wait for the asynchronous task to complete)
-            result = writer.result()
+        # Get the result (wait for the asynchronous task to complete)
+        result = writer.result()
 
-            # Check if the result matches the original DataFrame
-            assert result.equals(df)
+        # Check if the result matches the original DataFrame
+        assert result.equals(df)
 
-            # Check if the output file exists
-            assert os.path.exists(writer.path)
+        # Check if the output file exists
+        assert Path(writer.path).exists()
 
-            # Check if the output file contains the correct data
-            output_df = pd.read_csv(writer.path)
-            assert output_df.equals(df)
+        # Check if the output file contains the correct data
+        output_df = pd.read_csv(writer.path)
+        assert output_df.equals(df)
 
-            # Create a new DataFrame to write
-            new_df = pd.DataFrame({"A": [7, 8, 9], "B": [10, 11, 12]})
+        # Create a new DataFrame to write
+        new_df = pd.DataFrame({"A": [7, 8, 9], "B": [10, 11, 12]})
 
-            # Create new Writer instance with the same output file
-            writer = DataFrameWriter(os.path.join(tmp_dir, "output.csv"))
+        # Create new Writer instance with the same output file
+        writer = DataFrameWriter(output_path)
 
-            # Write the new DataFrame asynchronously
-            writer.write(new_df)
+        # Write the new DataFrame asynchronously
+        writer.write(new_df)
 
-            # Get the result (wait for the asynchronous task to complete)
-            result = writer.result()
+        # Get the result (wait for the asynchronous task to complete)
+        result = writer.result()
 
-            # Check if the result matches the concatenated DataFrames
-            expected_result = pd.concat([df, new_df], ignore_index=True)
-            assert result.equals(expected_result)
+        # Check if the result matches the concatenated DataFrames
+        expected_result = pd.concat([df, new_df], ignore_index=True)
+        assert result.equals(expected_result)
 
-            # Check if the output file contains the correct data
-            output_df = pd.read_csv(writer.path)
-            assert output_df.equals(expected_result)
+        # Check if the output file contains the correct data
+        output_df = pd.read_csv(writer.path)
+        assert output_df.equals(expected_result)
 
 
 class TestZMQ:
@@ -212,184 +204,165 @@ class TestZMQ:
 
 
 class TestStreamWriter:
-    def test_without_gap(self):
-        with tempfile.TemporaryDirectory() as tempdir:
-            data = np.random.randint(
-                low=-1000, high=1000, size=(1000, 10), dtype=np.int32
-            )
-            starttime = np.datetime64("2023-01-01T00:00:00")
-            endtime = starttime + np.timedelta64(10, "ms") * (data.shape[0] - 1)
-            distance = 5.0 * np.arange(data.shape[1])
+    def test_without_gap(self, tmp_path):
+        data = np.random.randint(low=-1000, high=1000, size=(1000, 10), dtype=np.int32)
+        starttime = np.datetime64("2023-01-01T00:00:00")
+        endtime = starttime + np.timedelta64(10, "ms") * (data.shape[0] - 1)
+        distance = 5.0 * np.arange(data.shape[1])
 
-            da = xd.DataArray(
-                data=data,
-                coords={
-                    "time": {
-                        "tie_indices": [0, data.shape[0] - 1],
-                        "tie_values": [starttime, endtime],
-                    },
-                    "distance": distance,
+        da = xd.DataArray(
+            data=data,
+            coords={
+                "time": {
+                    "tie_indices": [0, data.shape[0] - 1],
+                    "tie_values": [starttime, endtime],
                 },
-            )
+                "distance": distance,
+            },
+        )
 
-            atom = lambda da, **kwargs: da.to_stream(
-                network="NT",
-                station="ST{:03}",
-                channel="HN1",
-                location="00",
-                dim={"distance": "time"},
-            )
+        atom = lambda da, **kwargs: da.to_stream(
+            network="NT",
+            station="ST{:03}",
+            channel="HN1",
+            location="00",
+            dim={"distance": "time"},
+        )
 
-            data_loader = DataArrayLoader(da, chunks={"time": 100})
+        data_loader = DataArrayLoader(da, chunks={"time": 100})
 
-            kw_merge = {"method": 1}
-            kw_write = {"reclen": 4096}
-            data_writer = StreamWriter(
-                tempdir, "M", kw_merge, kw_write, output_format="SDS"
-            )
+        kw_merge = {"method": 1}
+        kw_write = {"reclen": 4096}
+        data_writer = StreamWriter(
+            tmp_path, "M", kw_merge, kw_write, output_format="SDS"
+        )
 
-            st = xp.process(atom, data_loader, data_writer)
+        st = xp.process(atom, data_loader, data_writer)
 
-            assert isinstance(st, obspy.Stream)
-            assert len(st) == 10
-            tr = st[0]
-            assert tr.stats.network == "NT"
-            assert tr.stats.station == "ST001"
-            assert tr.stats.channel == "HN1"
-            assert tr.stats.location == "00"
-            assert tr.stats.npts == 1000
-            assert np.array_equal(tr.data, data[:, 0])
-            assert tr.stats.starttime == obspy.UTCDateTime(str(starttime))
-            path = os.path.join(
-                tempdir,
-                "2023",
-                "NT",
-                "ST001",
-                "HN1.D",
-                "NT.ST001.00.HN1.D.2023.001",
-            )
-            assert os.path.exists(path)
-            st = obspy.read(path)
-            assert len(st) == 1
-            assert len(glob(os.path.join(tempdir, "**", "*.001"), recursive=True)) == 10
+        assert isinstance(st, obspy.Stream)
+        assert len(st) == 10
+        tr = st[0]
+        assert tr.stats.network == "NT"
+        assert tr.stats.station == "ST001"
+        assert tr.stats.channel == "HN1"
+        assert tr.stats.location == "00"
+        assert tr.stats.npts == 1000
+        assert np.array_equal(tr.data, data[:, 0])
+        assert tr.stats.starttime == obspy.UTCDateTime(str(starttime))
+        path = (
+            tmp_path / "2023" / "NT" / "ST001" / "HN1.D" / "NT.ST001.00.HN1.D.2023.001"
+        )
+        assert path.exists()
+        st = obspy.read(path)
+        assert len(st) == 1
+        assert len(list(tmp_path.rglob("*.001"))) == 10
 
-    def test_with_gap(self):
-        with tempfile.TemporaryDirectory() as tempdir:
-            da = xd.DataArray(
-                data=np.random.randint(
-                    low=-1000, high=1000, size=(900, 10), dtype=np.int32
-                ),
-                coords={
-                    "time": {
-                        "tie_indices": [0, 399, 400, 899],
-                        "tie_values": np.array(
-                            [
-                                "2023-01-01T00:00:00.000",
-                                "2023-01-01T00:00:03.990",
-                                "2023-01-01T00:00:05.000",
-                                "2023-01-01T00:00:09.990",
-                            ],
-                            dtype="datetime64[ms]",
-                        ),
-                    },
-                    "distance": 5.0 * np.arange(10),
+    def test_with_gap(self, tmp_path):
+        da = xd.DataArray(
+            data=np.random.randint(
+                low=-1000, high=1000, size=(900, 10), dtype=np.int32
+            ),
+            coords={
+                "time": {
+                    "tie_indices": [0, 399, 400, 899],
+                    "tie_values": np.array(
+                        [
+                            "2023-01-01T00:00:00.000",
+                            "2023-01-01T00:00:03.990",
+                            "2023-01-01T00:00:05.000",
+                            "2023-01-01T00:00:09.990",
+                        ],
+                        dtype="datetime64[ms]",
+                    ),
                 },
-            )
-            atom = lambda da, **kwargs: da.to_stream(
-                network="NT",
-                station="ST{:03}",
-                channel="HN1",
-                location="00",
-                dim={"distance": "time"},
-            )
+                "distance": 5.0 * np.arange(10),
+            },
+        )
+        atom = lambda da, **kwargs: da.to_stream(
+            network="NT",
+            station="ST{:03}",
+            channel="HN1",
+            location="00",
+            dim={"distance": "time"},
+        )
 
-            data_loader = DataArrayLoader(da, chunks={"time": 100})
+        data_loader = DataArrayLoader(da, chunks={"time": 100})
 
-            kw_merge = {"method": 1}
-            kw_write = {"reclen": 4096}
-            data_writer = StreamWriter(
-                tempdir, "M", kw_merge, kw_write, output_format="SDS"
-            )
+        kw_merge = {"method": 1}
+        kw_write = {"reclen": 4096}
+        data_writer = StreamWriter(
+            tmp_path, "M", kw_merge, kw_write, output_format="SDS"
+        )
 
-            st = xp.process(atom, data_loader, data_writer)
+        st = xp.process(atom, data_loader, data_writer)
 
-            assert isinstance(st, obspy.Stream)
-            assert len(st) == 10
-            tr = st[0]
-            assert isinstance(tr.data, np.ma.masked_array)
-            assert tr.stats.network == "NT"
-            assert tr.stats.station == "ST001"
-            assert tr.stats.channel == "HN1"
-            assert tr.stats.location == "00"
-            tr1, tr2 = tr.split()
-            assert tr1.stats.npts == 400
-            assert tr2.stats.npts == 500
-            assert np.array_equal(tr1.data, da.values[0:400, 0])
-            assert np.array_equal(tr2.data, da.values[400:900, 0])
-            assert tr1.stats.starttime == obspy.UTCDateTime("2023-01-01T00:00:00.000")
-            assert tr2.stats.starttime == obspy.UTCDateTime("2023-01-01T00:00:05.000")
-            path = os.path.join(
-                tempdir,
-                "2023",
-                "NT",
-                "ST001",
-                "HN1.D",
-                "NT.ST001.00.HN1.D.2023.001",
-            )
-            assert os.path.exists(path)
-            st = obspy.read(path)
-            assert len(st) == 2
-            assert len(glob(os.path.join(tempdir, "**", "*.001"), recursive=True)) == 10
+        assert isinstance(st, obspy.Stream)
+        assert len(st) == 10
+        tr = st[0]
+        assert isinstance(tr.data, np.ma.masked_array)
+        assert tr.stats.network == "NT"
+        assert tr.stats.station == "ST001"
+        assert tr.stats.channel == "HN1"
+        assert tr.stats.location == "00"
+        tr1, tr2 = tr.split()
+        assert tr1.stats.npts == 400
+        assert tr2.stats.npts == 500
+        assert np.array_equal(tr1.data, da.values[0:400, 0])
+        assert np.array_equal(tr2.data, da.values[400:900, 0])
+        assert tr1.stats.starttime == obspy.UTCDateTime("2023-01-01T00:00:00.000")
+        assert tr2.stats.starttime == obspy.UTCDateTime("2023-01-01T00:00:05.000")
+        path = (
+            tmp_path / "2023" / "NT" / "ST001" / "HN1.D" / "NT.ST001.00.HN1.D.2023.001"
+        )
+        assert path.exists()
+        st = obspy.read(path)
+        assert len(st) == 2
+        assert len(list(tmp_path.rglob("*.001"))) == 10
 
-    def test_flat(self):
-        with tempfile.TemporaryDirectory() as tempdir:
-            data = np.random.randint(
-                low=-1000, high=1000, size=(1000, 10), dtype=np.int32
-            )
-            starttime = np.datetime64("2023-01-01T00:00:00")
-            endtime = starttime + np.timedelta64(10, "ms") * (data.shape[0] - 1)
-            distance = 5.0 * np.arange(data.shape[1])
+    def test_flat(self, tmp_path):
+        data = np.random.randint(low=-1000, high=1000, size=(1000, 10), dtype=np.int32)
+        starttime = np.datetime64("2023-01-01T00:00:00")
+        endtime = starttime + np.timedelta64(10, "ms") * (data.shape[0] - 1)
+        distance = 5.0 * np.arange(data.shape[1])
 
-            da = xd.DataArray(
-                data=data,
-                coords={
-                    "time": {
-                        "tie_indices": [0, data.shape[0] - 1],
-                        "tie_values": [starttime, endtime],
-                    },
-                    "distance": distance,
+        da = xd.DataArray(
+            data=data,
+            coords={
+                "time": {
+                    "tie_indices": [0, data.shape[0] - 1],
+                    "tie_values": [starttime, endtime],
                 },
-            )
+                "distance": distance,
+            },
+        )
 
-            atom = lambda da, **kwargs: da.to_stream(
-                network="NT",
-                station="ST{:03}",
-                channel="HN1",
-                location="00",
-                dim={"distance": "time"},
-            )
+        atom = lambda da, **kwargs: da.to_stream(
+            network="NT",
+            station="ST{:03}",
+            channel="HN1",
+            location="00",
+            dim={"distance": "time"},
+        )
 
-            data_loader = DataArrayLoader(da, chunks={"time": 100})
+        data_loader = DataArrayLoader(da, chunks={"time": 100})
 
-            path = os.path.join(tempdir, "flat_output.mseed")
-            kw_merge = {"method": 1}
-            kw_write = {"reclen": 4096}
-            data_writer = StreamWriter(
-                path, "M", kw_merge, kw_write, output_format="flat"
-            )
+        path = tmp_path / "flat_output.mseed"
+        kw_merge = {"method": 1}
+        kw_write = {"reclen": 4096}
+        data_writer = StreamWriter(path, "M", kw_merge, kw_write, output_format="flat")
 
-            st = xp.process(atom, data_loader, data_writer)
+        st = xp.process(atom, data_loader, data_writer)
 
-            assert isinstance(st, obspy.Stream)
-            assert len(st) == 10
-            tr = st[0]
-            assert tr.stats.network == "NT"
-            assert tr.stats.station == "ST001"
-            assert tr.stats.channel == "HN1"
-            assert tr.stats.location == "00"
-            assert tr.stats.npts == 1000
-            assert np.array_equal(tr.data, data[:, 0])
-            assert tr.stats.starttime == obspy.UTCDateTime(str(starttime))
-            assert os.path.exists(path)
-            st = obspy.read(path)
-            assert len(st) == 10
+        assert isinstance(st, obspy.Stream)
+        assert len(st) == 10
+        tr = st[0]
+        assert tr.stats.network == "NT"
+        assert tr.stats.station == "ST001"
+        assert tr.stats.channel == "HN1"
+        assert tr.stats.location == "00"
+        assert tr.stats.npts == 1000
+        assert np.array_equal(tr.data, data[:, 0])
+        assert tr.stats.starttime == obspy.UTCDateTime(str(starttime))
+        assert path.exists()
+        st = obspy.read(path)
+        assert len(st) == 10

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -30,7 +30,7 @@ class TestProcessing:
 
         # generate test dataarray
         wavelet_wavefronts().to_netcdf(sample_path)
-        da = xd.open_dataarray(sample_path)
+        da = xd.open(sample_path)
 
         # declare processing sequence
         sos = sp.iirfilter(4, 0.1, btype="lowpass", output="sos")

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -209,10 +209,10 @@ class TestOpenMFDataArray:
         )
         for index, chunk in enumerate(xd.split(expected, 3, "time"), start=1):
             chunk.to_netcdf(tmp_path / f"chunk_{index}.nc")
-        result = xd.open_mfdataarray(str(tmp_path / "*.nc"))  # TODO: should accept Path
+        result = xd.open_mfdataarray(tmp_path / "*.nc")
         assert result.equals(expected)
         with (tmp_path / "corrupted.nc").open("wb") as f:
             f.write(b"corrupted")
         with pytest.warns(RuntimeWarning):
-            result = xd.open_mfdataarray(str(tmp_path / "*.nc"))
+            result = xd.open_mfdataarray(tmp_path / "*.nc")
         assert result.equals(expected)

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -216,3 +216,92 @@ class TestOpenMFDataArray:
         with pytest.warns(RuntimeWarning):
             result = xd.open_mfdataarray(tmp_path / "*.nc")
         assert result.equals(expected)
+
+
+class TestOpen:
+    def test_open_single_dataarray(self, tmp_path):
+        expected = xd.DataArray(
+            np.random.rand(10, 5),
+            coords={
+                "time": np.arange(10),
+                "space": np.arange(5),
+            },
+        )
+
+        path = tmp_path / "dataarray.nc"
+        expected.to_netcdf(path)
+
+        result = xd.open(path)
+        assert result.equals(expected)
+
+    def test_open_multiple_file_dataarray(self, tmp_path):
+        expected = xd.DataArray(
+            np.random.rand(10, 5),
+            coords={
+                "time": np.arange(10),
+                "space": np.arange(5),
+            },
+        )
+
+        file_paths = []
+        for index, chunk in enumerate(xd.split(expected, 3, "time"), start=1):
+            file_path = tmp_path / f"chunk_{index}.nc"
+            chunk.to_netcdf(file_path)
+            file_paths.append(file_path)
+
+        # glob patterns
+        result = xd.open(tmp_path / "*.nc")
+        assert result.equals(expected)
+        result = xd.open(tmp_path / "chunk_[1-3].nc")
+        assert result.equals(expected)
+        result = xd.open(tmp_path / "chunk_?.nc")
+        assert result.equals(expected)
+
+        # list of paths
+        result = xd.open(file_paths)
+        assert result.equals(expected)
+
+    def test_open_multiple_file_tree(self, tmp_path):
+        expected = xd.DataCollection(
+            {
+                "DAS01": xd.DataCollection(
+                    [
+                        xd.DataArray(
+                            np.random.rand(10, 5),
+                            coords={
+                                "time": np.arange(10),
+                                "space": np.arange(5),
+                            },
+                        )
+                    ],
+                    name="acquisition",
+                ),
+                "DAS02": xd.DataCollection(
+                    [
+                        xd.DataArray(
+                            np.random.rand(7, 3),
+                            coords={
+                                "time": np.arange(7),
+                                "space": np.arange(3),
+                            },
+                        )
+                    ],
+                    name="acquisition",
+                ),
+            },
+            name="station",
+        )
+
+        for station in expected:
+            dirpath = tmp_path / station
+            dirpath.mkdir()
+            for index, chunk in enumerate(
+                xd.split(expected[station][0], 3, "time"), start=1
+            ):
+                print(dirpath / f"chunk_{index}.nc")
+                chunk.to_netcdf(dirpath / f"chunk_{index}.nc")
+
+        print(tmp_path / "{station}" / "[acquisition].nc")
+        result = xd.open(tmp_path / "{station}" / "[acquisition].nc")
+        assert result.equals(expected)
+

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -218,7 +218,7 @@ class TestOpenMFDataArray:
         assert result.equals(expected)
 
 
-class TestOpen:
+class TestOpen:  # TODO: those tests are weirdly slow...
     def test_open_single_dataarray(self, tmp_path):
         expected = xd.DataArray(
             np.random.rand(10, 5),
@@ -298,10 +298,75 @@ class TestOpen:
             for index, chunk in enumerate(
                 xd.split(expected[station][0], 3, "time"), start=1
             ):
-                print(dirpath / f"chunk_{index}.nc")
                 chunk.to_netcdf(dirpath / f"chunk_{index}.nc")
 
-        print(tmp_path / "{station}" / "[acquisition].nc")
         result = xd.open(tmp_path / "{station}" / "[acquisition].nc")
         assert result.equals(expected)
 
+    def test_open_single_datacollection(self, tmp_path):
+        expected = xd.DataCollection(
+            [
+                xd.DataArray(
+                    np.random.rand(10, 5),
+                    coords={
+                        "time": np.arange(10),
+                        "space": np.arange(5),
+                    },
+                )
+            ]
+        )
+
+        expected.to_netcdf(tmp_path / "collection.nc")
+
+        result = xd.open(tmp_path / "collection.nc")
+        assert result.equals(expected)
+
+    def test_open_multiple_datacollection_with_glob(self, tmp_path):
+        expected = xd.DataCollection(
+            {
+                "DAS01": xd.DataCollection(
+                    [
+                        xd.DataArray(
+                            np.random.rand(10, 5),
+                            coords={
+                                "time": np.arange(10),
+                                "space": np.arange(5),
+                            },
+                        )
+                    ],
+                    name="acquisition",
+                ),
+                "DAS02": xd.DataCollection(
+                    [
+                        xd.DataArray(
+                            np.random.rand(7, 3),
+                            coords={
+                                "time": np.arange(7),
+                                "space": np.arange(3),
+                            },
+                        )
+                    ],
+                    name="acquisition",
+                ),
+            },
+            name="station",
+        )
+
+        expected.isel(time=slice(None, 3)).to_netcdf(tmp_path / "datacollection_1.nc")
+        expected.isel(time=slice(3, None)).to_netcdf(tmp_path / "datacollection_2.nc")
+
+        # glob patterns
+        result = xd.open(tmp_path / "datacollection_*.nc")
+        assert result.equals(expected)
+        result = xd.open(tmp_path / "datacollection_[1-2].nc")
+        assert result.equals(expected)
+        result = xd.open(tmp_path / "datacollection_?.nc")
+        assert result.equals(expected)
+
+        # list of paths
+        file_paths = [
+            tmp_path / "datacollection_1.nc",
+            tmp_path / "datacollection_2.nc",
+        ]
+        result = xd.open(file_paths)
+        assert result.equals(expected)

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -173,7 +173,7 @@ class TestSignal:
         for i, chunk in enumerate(chunks):
             chunk_path = tmp_path / f"chunk_{i}.nc"
             chunk.to_netcdf(chunk_path)
-        da_virtual = xd.open_mfdataarray(tmp_path / "chunk_*.nc")
+        da_virtual = xd.open(tmp_path / "chunk_*.nc")
         result = xs.decimate(da_virtual, 5, dim="time")
         assert result.equals(expected)
 

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,6 +1,3 @@
-import os
-import tempfile
-
 import numpy as np
 import scipy.signal as sp
 import xarray as xr
@@ -169,16 +166,15 @@ class TestSignal:
         )
         assert result.equals(expected)
 
-    def test_decimate_virtual_stack(self):
+    def test_decimate_virtual_stack(self, tmp_path):
         da = wavelet_wavefronts()
         expected = xs.decimate(da, 5, dim="time")
         chunks = xd.split(da, 5, "time")
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            for i, chunk in enumerate(chunks):
-                chunk_path = os.path.join(tmpdirname, f"chunk_{i}.nc")
-                chunk.to_netcdf(chunk_path)
-            da_virtual = xd.open_mfdataarray(os.path.join(tmpdirname, "chunk_*.nc"))
-            result = xs.decimate(da_virtual, 5, dim="time")
+        for i, chunk in enumerate(chunks):
+            chunk_path = tmp_path / f"chunk_{i}.nc"
+            chunk.to_netcdf(chunk_path)
+        da_virtual = xd.open_mfdataarray(tmp_path / "chunk_*.nc")
+        result = xs.decimate(da_virtual, 5, dim="time")
         assert result.equals(expected)
 
 

--- a/tests/test_virtual.py
+++ b/tests/test_virtual.py
@@ -22,7 +22,7 @@ class TestFunctional:  # TODO: move elsewhere
         for index, chunk in enumerate(chunks, start=1):
             chunk.to_netcdf(tmp_path / f"{index:03d}.nc")
 
-        da = xd.open_dataarray(tmp_path / "002.nc")
+        da = xd.open(tmp_path / "002.nc")
         datasource = da.data
         assert np.allclose(np.asarray(datasource[0]), da.load().values[0])
         assert np.allclose(np.asarray(datasource[0][1]), da.load().values[0][1])
@@ -62,7 +62,7 @@ class TestFunctional:  # TODO: move elsewhere
         for dtype in dtypes:
             expected = xd.DataArray(np.zeros((3, 5), dtype=dtype))
             expected.to_netcdf(tmp_path / "data.nc")
-            result = xd.open_dataarray(tmp_path / "data.nc")
+            result = xd.open(tmp_path / "data.nc")
             assert result.equals(expected)
 
 

--- a/tests/test_virtual.py
+++ b/tests/test_virtual.py
@@ -1,6 +1,3 @@
-import os
-import tempfile
-
 import h5py
 import numpy as np
 import pytest
@@ -19,37 +16,32 @@ from xdas.virtual import (
 
 
 class TestFunctional:  # TODO: move elsewhere
-    def test_all(self):
-        with tempfile.TemporaryDirectory() as dirpath:
-            expected = wavelet_wavefronts()
-            chunks = xd.split(expected, 3)
-            for index, chunk in enumerate(chunks, start=1):
-                chunk.to_netcdf(os.path.join(dirpath, f"{index:03d}.nc"))
+    def test_all(self, tmp_path):
+        expected = wavelet_wavefronts()
+        chunks = xd.split(expected, 3)
+        for index, chunk in enumerate(chunks, start=1):
+            chunk.to_netcdf(tmp_path / f"{index:03d}.nc")
 
-            da = xd.open_dataarray(os.path.join(dirpath, "002.nc"))
-            datasource = da.data
-            assert np.allclose(np.asarray(datasource[0]), da.load().values[0])
-            assert np.allclose(np.asarray(datasource[0][1]), da.load().values[0][1])
-            assert np.allclose(
-                np.asarray(datasource[:, 0][1]), da.load().values[:, 0][1]
-            )
-            assert np.allclose(
-                np.asarray(datasource[:, 0][1]), da.load().values[:, 0][1]
-            )
-            assert np.allclose(np.asarray(datasource[10:][1]), da.load().values[10:][1])
-            with pytest.raises(IndexError):
-                datasource[1, 2, 3]
-            assert np.allclose(np.asarray(datasource[10:][1]), da.load().values[10:][1])
-            assert array_identical(da.load().data, da.load().data)
-            da1 = da.sel(
-                time=slice("2023-01-01T00:00:03", None),
-                distance=slice(1000, None),
-            ).load()
-            da2 = da.load().sel(
-                time=slice("2023-01-01T00:00:03", None),
-                distance=slice(1000, None),
-            )
-            assert da1.equals(da2)
+        da = xd.open_dataarray(tmp_path / "002.nc")
+        datasource = da.data
+        assert np.allclose(np.asarray(datasource[0]), da.load().values[0])
+        assert np.allclose(np.asarray(datasource[0][1]), da.load().values[0][1])
+        assert np.allclose(np.asarray(datasource[:, 0][1]), da.load().values[:, 0][1])
+        assert np.allclose(np.asarray(datasource[:, 0][1]), da.load().values[:, 0][1])
+        assert np.allclose(np.asarray(datasource[10:][1]), da.load().values[10:][1])
+        with pytest.raises(IndexError):
+            datasource[1, 2, 3]
+        assert np.allclose(np.asarray(datasource[10:][1]), da.load().values[10:][1])
+        assert array_identical(da.load().data, da.load().data)
+        da1 = da.sel(
+            time=slice("2023-01-01T00:00:03", None),
+            distance=slice(1000, None),
+        ).load()
+        da2 = da.load().sel(
+            time=slice("2023-01-01T00:00:03", None),
+            distance=slice(1000, None),
+        )
+        assert da1.equals(da2)
 
     def test_dtypes(self, tmp_path):
         dtypes = (

--- a/xdas/__init__.py
+++ b/xdas/__init__.py
@@ -34,6 +34,7 @@ from .core.routines import (
     combine_by_coords,
     combine_by_field,
     concatenate,
+    open,
     open_dataarray,
     open_datacollection,
     open_mfdataarray,

--- a/xdas/core/dataarray.py
+++ b/xdas/core/dataarray.py
@@ -2,6 +2,7 @@ import copy
 import os
 import warnings
 from functools import partial
+from pathlib import Path
 
 import h5netcdf
 import h5py
@@ -882,6 +883,9 @@ class DataArray(NDArrayOperatorsMixin):
         ...     da.to_netcdf(tmpfile, encoding=encoding)
 
         """
+        if isinstance(fname, Path):
+            fname = str(fname)
+
         if virtual is None:
             virtual = isinstance(self.data, (VirtualArray, DaskArray))
 
@@ -960,6 +964,9 @@ class DataArray(NDArrayOperatorsMixin):
         DataArray
             The openend data array.
         """
+        if isinstance(fname, Path):
+            fname = str(fname)
+
         # read metadata
         with xr.open_dataset(
             fname, group=group, engine="h5netcdf", decode_timedelta=False

--- a/xdas/core/datacollection.py
+++ b/xdas/core/datacollection.py
@@ -1,5 +1,6 @@
 import os
 from fnmatch import fnmatch
+from pathlib import Path
 
 import h5py
 
@@ -172,6 +173,8 @@ class DataCollection:
             The opened data collection.
 
         """
+        if isinstance(fname, Path):
+            fname = str(fname)
         self = DataMapping.from_netcdf(fname, group)
         try:
             keys = [int(key) for key in self.keys()]
@@ -261,6 +264,9 @@ class DataMapping(DataCollection, dict):
 
     @classmethod
     def from_netcdf(cls, fname, group=None):
+        if isinstance(fname, Path):
+            fname = str(fname)
+
         with h5py.File(fname, "r") as file:
             if group is None:
                 group = file[list(file.keys())[0]]

--- a/xdas/core/datacollection.py
+++ b/xdas/core/datacollection.py
@@ -273,6 +273,15 @@ class DataMapping(DataCollection, dict):
             else:
                 group = file[group]
             name = group.name.split("/")[-1]
+            if isinstance(group, h5py.Dataset):
+                raise ValueError(
+                    "it looks like you are trying to open a data array as a data collection."
+                )
+            else:
+                if not isinstance(group, h5py.Group):
+                    raise RuntimeError(
+                        "something went wrong while opening the data collection."
+                    )
             keys = list(group.keys())
             self = cls({}, name=None if name == "collection" else name)
             for key in keys:

--- a/xdas/core/routines.py
+++ b/xdas/core/routines.py
@@ -387,29 +387,31 @@ def open_mfdataarray(
             "The maximum number of file that can be opened at once is for now limited "
             "to 100 000."
         )
-    max_workers = 1 if engine == "miniseed" else None  # TODO: dirty fix
-    with ProcessPoolExecutor(max_workers=max_workers) as executor:
-        futures_to_paths = {
-            executor.submit(open_dataarray, path, engine=engine, **kwargs): path
-            for path in paths
-        }
-        if verbose:
-            iterator = tqdm(
-                as_completed(futures_to_paths),
-                total=len(futures_to_paths),
-                desc="Fetching metadata from files",
-            )
-        else:
-            iterator = as_completed(futures_to_paths)
-        objs = []
-        for future in iterator:
-            try:
-                obj = future.result()
-            except Exception as e:
-                path = futures_to_paths[future]
-                warnings.warn(f"could not open {path}: {e}", RuntimeWarning)
+    if engine == "miniseed": # TODO: dirty fix
+        objs = [open_dataarray(path, engine=engine, **kwargs) for path in paths]
+    else:
+        with ProcessPoolExecutor() as executor:
+            futures_to_paths = {
+                executor.submit(open_dataarray, path, engine=engine, **kwargs): path
+                for path in paths
+            }
+            if verbose:
+                iterator = tqdm(
+                    as_completed(futures_to_paths),
+                    total=len(futures_to_paths),
+                    desc="Fetching metadata from files",
+                )
             else:
-                objs.append(obj)
+                iterator = as_completed(futures_to_paths)
+            objs = []
+            for future in iterator:
+                try:
+                    obj = future.result()
+                except Exception as e:
+                    path = futures_to_paths[future]
+                    warnings.warn(f"could not open {path}: {e}", RuntimeWarning)
+                else:
+                    objs.append(obj)
     return combine_by_coords(objs, dim, tolerance, squeeze, None, verbose)
 
 

--- a/xdas/core/routines.py
+++ b/xdas/core/routines.py
@@ -18,6 +18,9 @@ from .dataarray import DataArray
 from .datacollection import DataCollection, DataMapping, DataSequence
 
 
+def open(): ...  # TODO
+
+
 def open_mfdatacollection(
     paths, dim="first", tolerance=None, squeeze=False, verbose=False
 ):

--- a/xdas/core/routines.py
+++ b/xdas/core/routines.py
@@ -20,24 +20,57 @@ from .datacollection import DataCollection, DataMapping, DataSequence
 
 
 def open(paths, dim="first", tolerance=None, squeeze=None, engine=None, verbose=False):
-    if isinstance(paths, Path):
-        paths = str(paths)
+    paths = _ensure_str_paths(paths)
     if isinstance(paths, str):
         if "{" in paths:
-            squeeze = False if squeeze is None else squeeze
-            return open_mfdatatree(paths, dim, tolerance, squeeze, engine, verbose)
+            method = "tree-like"
         elif "*" in paths or "?" in paths or "[" in paths:
-            squeeze = True if squeeze is None else squeeze
-            return open_mfdataarray(paths, dim, tolerance, squeeze, engine, verbose)
+            method = "multi-file"
         else:
-            return open_dataarray(paths, engine=engine)
+            method = "single-file"
     elif isinstance(paths, list):
-        squeeze = True if squeeze is None else squeeze
-        return open_mfdataarray(paths, dim, tolerance, squeeze, engine, verbose)
+        method = "multi-file"
     else:
         raise ValueError(
             f"`paths` must be either a string or a list, found {type(paths)}"
         )
+    match method:
+        case "single-file":
+            if engine is None:
+                try:
+                    return open_datacollection(paths)
+                except ValueError:
+                    pass
+            return open_dataarray(paths, engine=engine)
+        case "multi-file":
+            if engine is None:
+                try:
+                    return open_mfdatacollection(
+                        paths,
+                        dim,
+                        tolerance,
+                        squeeze=False if squeeze is None else squeeze,
+                        verbose=verbose,
+                    )
+                except ValueError:
+                    pass
+            return open_mfdataarray(
+                paths,
+                dim,
+                tolerance,
+                squeeze=True if squeeze is None else squeeze,
+                engine=engine,
+                verbose=verbose,
+            )
+        case "tree-like":
+            return open_mfdatatree(
+                paths,
+                dim,
+                tolerance,
+                squeeze=False if squeeze is None else squeeze,
+                engine=engine,
+                verbose=verbose,
+            )
 
 
 def open_mfdatacollection(

--- a/xdas/core/routines.py
+++ b/xdas/core/routines.py
@@ -19,7 +19,104 @@ from .dataarray import DataArray
 from .datacollection import DataCollection, DataMapping, DataSequence
 
 
-def open(paths, dim="first", tolerance=None, squeeze=None, engine=None, verbose=False):
+def open(
+    paths,
+    dim="first",
+    tolerance=None,
+    squeeze=None,
+    engine=None,
+    verbose=False,
+    **kwargs,
+):
+    """
+    Open one or several files as a data array or collection.
+
+    Automatically dispatches to the appropriate reader based on the shape of `paths`:
+
+    - **Single file** (plain path string): tries to open as a data collection first,
+      falls back to a data array if the file does not contain a data collection.
+    - **Multi-file** (wildcarded string with ``*``, ``?``, or ``[…]``, or a list of
+      paths): tries to open and combine as a multi-file data collection first, falls
+      back to a multi-file data array if the files are not data collections.
+    - **Tree-like** (string containing ``{field}`` placeholders):
+      opens a directory tree as a nested data collection using
+      :func:`open_mfdatatree`.
+
+    Parameters
+    ----------
+    paths : str or list of str
+        The path(s) to open. Can be:
+
+        - A plain file path (single file).
+        - A shell-style wildcard string (``*``, ``?``, ``[…]``) matching multiple
+          files.
+        - A list of explicit file paths.
+        - A tree descriptor string containing ``{field}`` (dict level) and
+          ``[field]`` (list level) placeholders.
+    dim : str, optional
+        The dimension along which multiple files are concatenated. Ignored when
+        opening a single file. Default is ``"first"``.
+    tolerance : float or timedelta64, optional
+        Maximum gap or overlap allowed between consecutive files to still be
+        considered continuous. For time coordinates, numeric values are interpreted
+        as seconds. Ignored when opening a single file. Default is zero tolerance.
+    squeeze : bool or None, optional
+        Whether to return a DataArray instead of a DataCollection when the result
+        contains only one data array. When ``None`` (default), the behaviour depends
+        on the dispatch path: ``True`` for multi-file data arrays, ``False``
+        otherwise. Ignored when opening a single file.
+    engine : str or callable, optional
+        The file format engine to use, or a custom read callable. When ``None``
+        (default), the xdas NetCDF format is assumed. Providing an engine skips the
+        automatic DataCollection detection.
+    verbose : bool, optional
+        Whether to display a progress bar while reading metadata. Ignored when
+        opening a single file. Default is ``False``.
+    **kwargs
+        Additional keyword arguments forwarded to the underlying engine read
+        function. Only used when `engine` is not ``None``.
+
+    Returns
+    -------
+    DataArray or DataCollection
+        The opened data. The exact type depends on the dispatch path and the
+        ``squeeze`` setting.
+
+    Raises
+    ------
+    ValueError
+        If `paths` is neither a string nor a list.
+    FileNotFoundError
+        If no file matching `paths` can be found.
+
+    See Also
+    --------
+    open_dataarray : Open a single DataArray file.
+    open_datacollection : Open a single DataCollection file.
+    open_mfdataarray : Open and combine multiple DataArray files.
+    open_mfdatacollection : Open and combine multiple DataCollection files.
+    open_mfdatatree : Open a directory tree as a nested DataCollection.
+
+    Examples
+    --------
+    Open a single file (auto-detects DataCollection vs DataArray):
+
+    >>> import xdas as xd
+    >>> da = xd.open("path/to/file.nc")  # doctest: +SKIP
+
+    Open multiple files with a wildcard:
+
+    >>> da = xd.open("path/to/files/*.nc")  # doctest: +SKIP
+
+    Open a list of explicit paths:
+
+    >>> da = xd.open(["file1.nc", "file2.nc"])  # doctest: +SKIP
+
+    Open a directory tree:
+
+    >>> dc = xd.open("/data/{node}/[acq].nc", engine="asn")  # doctest: +SKIP
+
+    """
     paths = _ensure_str_paths(paths)
     if isinstance(paths, str):
         if "{" in paths:
@@ -41,7 +138,7 @@ def open(paths, dim="first", tolerance=None, squeeze=None, engine=None, verbose=
                     return open_datacollection(paths)
                 except ValueError:
                     pass
-            return open_dataarray(paths, engine=engine)
+            return open_dataarray(paths, engine=engine, **kwargs)
         case "multi-file":
             if engine is None:
                 try:
@@ -61,6 +158,7 @@ def open(paths, dim="first", tolerance=None, squeeze=None, engine=None, verbose=
                 squeeze=True if squeeze is None else squeeze,
                 engine=engine,
                 verbose=verbose,
+                **kwargs,
             )
         case "tree-like":
             return open_mfdatatree(
@@ -70,6 +168,7 @@ def open(paths, dim="first", tolerance=None, squeeze=None, engine=None, verbose=
                 squeeze=False if squeeze is None else squeeze,
                 engine=engine,
                 verbose=verbose,
+                **kwargs,
             )
 
 

--- a/xdas/core/routines.py
+++ b/xdas/core/routines.py
@@ -486,7 +486,7 @@ def open_mfdataarray(
             "The maximum number of file that can be opened at once is for now limited "
             "to 100 000."
         )
-    if engine == "miniseed": # TODO: dirty fix
+    if engine == "miniseed":  # TODO: dirty fix
         objs = [open_dataarray(path, engine=engine, **kwargs) for path in paths]
     else:
         with ProcessPoolExecutor() as executor:

--- a/xdas/core/routines.py
+++ b/xdas/core/routines.py
@@ -19,7 +19,25 @@ from .dataarray import DataArray
 from .datacollection import DataCollection, DataMapping, DataSequence
 
 
-def open(): ...  # TODO
+def open(paths, dim="first", tolerance=None, squeeze=None, engine=None, verbose=False):
+    if isinstance(paths, Path):
+        paths = str(paths)
+    if isinstance(paths, str):
+        if "{" in paths:
+            squeeze = False if squeeze is None else squeeze
+            return open_mfdatatree(paths, dim, tolerance, squeeze, engine, verbose)
+        elif "*" in paths or "?" in paths or "[" in paths:
+            squeeze = True if squeeze is None else squeeze
+            return open_mfdataarray(paths, dim, tolerance, squeeze, engine, verbose)
+        else:
+            return open_dataarray(paths, engine=engine)
+    elif isinstance(paths, list):
+        squeeze = True if squeeze is None else squeeze
+        return open_mfdataarray(paths, dim, tolerance, squeeze, engine, verbose)
+    else:
+        raise ValueError(
+            f"`paths` must be either a string or a list, found {type(paths)}"
+        )
 
 
 def open_mfdatacollection(
@@ -58,8 +76,8 @@ def open_mfdatacollection(
         The combined data collection
 
     """
-    if isinstance(paths, Path):
-        paths = str(paths)
+    paths = _ensure_str_paths(paths)
+
     if isinstance(paths, str):
         paths = sorted(glob(paths))
     elif isinstance(paths, list):
@@ -167,8 +185,7 @@ def open_mfdatatree(
 
 
     """
-    if isinstance(paths, Path):
-        paths = str(paths)
+    paths = _ensure_str_paths(paths)
 
     placeholders = re.findall(r"[\{\[].*?[\}\]]", paths)
 
@@ -319,8 +336,7 @@ def open_mfdataarray(
     FileNotFound
         If no file can be found.
     """
-    if isinstance(paths, Path):
-        paths = str(paths)
+    paths = _ensure_str_paths(paths)
     if isinstance(paths, str):
         paths = sorted(glob(paths))
     elif isinstance(paths, list):
@@ -395,8 +411,7 @@ def open_dataarray(fname, group=None, engine=None, **kwargs):
     FileNotFound
         If no file can be found.
     """
-    if isinstance(fname, Path):
-        fname = str(fname)
+    fname = _ensure_str_paths(fname)
     if not os.path.exists(fname):
         raise FileNotFoundError("no file to open")
     if engine is None:
@@ -431,8 +446,7 @@ def open_datacollection(fname, group=None):
     FileNotFound
         If no file can be found.
     """
-    if isinstance(fname, Path):
-        fname = str(fname)
+    fname = _ensure_str_paths(fname)
     if not os.path.exists(fname):
         raise FileNotFoundError("no file to open")
     return DataCollection.from_netcdf(fname, group)
@@ -1048,3 +1062,11 @@ def _get_timeline_dataframe(obj, dim="first", name=None):
             f"`obj` must be a DataArray of a DataCollection, found {type(obj)}"
         )
     return dataframe
+
+
+def _ensure_str_paths(paths):
+    if isinstance(paths, Path):
+        paths = str(paths)
+    if isinstance(paths, list):
+        paths = [str(path) if isinstance(path, Path) else path for path in paths]
+    return paths

--- a/xdas/core/routines.py
+++ b/xdas/core/routines.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from glob import glob
 from itertools import pairwise
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -57,6 +58,8 @@ def open_mfdatacollection(
         The combined data collection
 
     """
+    if isinstance(paths, Path):
+        paths = str(paths)
     if isinstance(paths, str):
         paths = sorted(glob(paths))
     elif isinstance(paths, list):
@@ -164,6 +167,9 @@ def open_mfdatatree(
 
 
     """
+    if isinstance(paths, Path):
+        paths = str(paths)
+
     placeholders = re.findall(r"[\{\[].*?[\}\]]", paths)
 
     seen = set()
@@ -313,6 +319,8 @@ def open_mfdataarray(
     FileNotFound
         If no file can be found.
     """
+    if isinstance(paths, Path):
+        paths = str(paths)
     if isinstance(paths, str):
         paths = sorted(glob(paths))
     elif isinstance(paths, list):
@@ -387,6 +395,8 @@ def open_dataarray(fname, group=None, engine=None, **kwargs):
     FileNotFound
         If no file can be found.
     """
+    if isinstance(fname, Path):
+        fname = str(fname)
     if not os.path.exists(fname):
         raise FileNotFoundError("no file to open")
     if engine is None:
@@ -421,6 +431,8 @@ def open_datacollection(fname, group=None):
     FileNotFound
         If no file can be found.
     """
+    if isinstance(fname, Path):
+        fname = str(fname)
     if not os.path.exists(fname):
         raise FileNotFoundError("no file to open")
     return DataCollection.from_netcdf(fname, group)

--- a/xdas/processing/core.py
+++ b/xdas/processing/core.py
@@ -1,6 +1,7 @@
 import os
 from concurrent.futures import ThreadPoolExecutor
 from glob import glob
+from pathlib import Path
 from queue import Queue
 from tempfile import TemporaryDirectory
 
@@ -137,7 +138,7 @@ class DataArrayLoader:
 class RealTimeLoader(Observer):
     def __init__(self, path, engine="netcdf"):
         super().__init__()
-        self.path = path
+        self.path = str(path) if isinstance(path, Path) else path
         self.queue = Queue()
         self.handler = Handler(self.queue, engine)
         self.schedule(self.handler, self.path, recursive=True)
@@ -170,7 +171,7 @@ class DataArrayWriter:
 
     Parameters
     ----------
-    dirpath : str or path
+    dirpath : str or Path
         The directory to store the output of a processing pipeline. The directory needs
         to exist and be empty.
     encoding : dict
@@ -190,7 +191,7 @@ class DataArrayWriter:
     """
 
     def __init__(self, dirpath, encoding=None):
-        self.dirpath = dirpath
+        self.dirpath = str(dirpath) if isinstance(dirpath, Path) else dirpath
         self.encoding = encoding
         self.queue = Queue(maxsize=1)
         self.results = []
@@ -258,7 +259,7 @@ class DataFrameWriter:
     """
 
     def __init__(self, path, parse_dates=False):
-        self.path = path
+        self.path = str(path) if isinstance(path, Path) else path
         self.parse_dates = parse_dates
         self.queue = Queue(maxsize=1)
         self.executor = ThreadPoolExecutor(1)
@@ -391,6 +392,7 @@ class StreamWriter:
     def __init__(
         self, path, dataquality, kw_merge=None, kw_write=None, output_format="SDS"
     ):
+        path = str(path) if isinstance(path, Path) else path
         if output_format == "SDS":
             os.makedirs(path, exist_ok=True)
             self.dirpath = path


### PR DESCRIPTION
Because of the various structures and file configurations, Xdas has many `open_*` functions. Though it should by possible to unify them all with a unique `open` function. This function should look at the `paths` argument to infer weather a `open_mf...` `open_mftree...` or simple `open_...` should be use. It should then inspect the files to open to switch between `...dataarray` or `...datacollection`.