### PR TITLE
Fix idle Writers and Loaders

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,16 +9,16 @@
 
 ### Improvements
 - New `io.Engine` backend system to register different file formats (@atrabattoni).
-- Make `open_mfdataarray` raise `RuntimeError` when openning all files fails (@asladen). 
+- Most `xdas.open_*` functions now have a `create_dirs` argument to creating intermediate directories if necessary (@aurelienfalco).
+- Make `open_mfdataarray` raise `RuntimeError` when opening all files fails (@asladen). 
 - Add "prodml" engine (@atrabattoni) and make "optasense" and "sintela" aliases of it (@atrabattoni). 
 
 ### Bugs Fixed
-- Fix Memory accumulation when slicing multiple times data arrays, e.g. when using atoms (@atrabattoni).
+- Fix **memory accumulation** when slicing multiple times data arrays, e.g. when using atoms (@atrabattoni) (@atrabattoni).
+- Fix **non-terminating loaders and writers** in `xdas.processing` (@atrabattoni).
 - Fix/improve distance handling for: "apsensing", "febus", "optasense", "silixa", and "sintela" (@atrabattoni).
 - Add dim swapping handling for the "prodml" based engines with the `swapped_dims=False` kwarg (@atrabattoni).
 - Fix ASN ROI handling (@asladen).
-
-## 0.2.5
 
 ## 0.2.5
 - Add SampleCoordinate for more SEED-like coordinates and refactor the coordinate backend (@atrabattoni).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ tests = [
     "dascore",
     "pytest",
     "pytest-cov",
+    "pytest-timeout",
     "psutil",
     "seisbench",
     "torch",

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -26,30 +26,34 @@ from xdas.synthetics import wavelet_wavefronts
 
 
 class TestDataArrayLoader:
-    @pytest.mark.timeout(1)
-    def test_init_and_stop(self):
+
+    def test_init(self):
         da = xd.DataArray(np.random.rand(1000, 100), dims=("time", "distance"))
         dl = DataArrayLoader(da, {"time": 100})
+        assert dl.da is da
         assert dl.chunk_dim == "time"
         assert dl.chunk_size == 100
+        assert dl.prefetch == 1
+        assert dl.max_workers == 1
         assert len(dl) == 10
-        dl.shutdown()
 
-    @pytest.mark.timeout(1)
-    def test_context_manager(self):
+    @pytest.mark.parametrize(
+        "prefetch,max_workers",
+        [
+            (0, 1),
+            (1, 1),
+            (2, 2),
+            (4, 2),
+            (8, 4),
+        ],
+    )
+    def test_chunks_integrity(self, prefetch, max_workers):
         da = xd.DataArray(np.random.rand(1000, 100), dims=("time", "distance"))
-        with DataArrayLoader(da, {"time": 100}) as dl:
-            assert dl.da is da
-
-    @pytest.mark.timeout(1)
-    def test_chunks_integrity(self):
-        da = xd.DataArray(np.random.rand(1000, 100), dims=("time", "distance"))
-        dl = DataArrayLoader(da, {"time": 100})
+        dl = DataArrayLoader(da, {"time": 100}, prefetch, max_workers)
         chunks = [chunk for chunk in dl]
         result = xd.concatenate(chunks)
         assert result.equals(da)
 
-    @pytest.mark.timeout(1)
     def test_error_handling(self):
         da = xd.DataArray(np.random.rand(1000, 100), dims=("time", "distance"))
         with pytest.raises(TypeError):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -33,7 +33,7 @@ class TestDataArrayLoader:
         assert dl.chunk_dim == "time"
         assert dl.chunk_size == 100
         assert len(dl) == 10
-        dl.stop()
+        dl.shutdown()
 
     @pytest.mark.timeout(1)
     def test_context_manager(self):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -32,6 +32,7 @@ class TestDataArrayLoader:
         dl = DataArrayLoader(da, {"time": 100})
         assert dl.chunk_dim == "time"
         assert dl.chunk_size == 100
+        assert len(dl) == 10
         dl.stop()
 
     @pytest.mark.timeout(1)
@@ -39,6 +40,14 @@ class TestDataArrayLoader:
         da = xd.DataArray(np.random.rand(1000, 100), dims=("time", "distance"))
         with DataArrayLoader(da, {"time": 100}) as dl:
             assert dl.da is da
+
+    @pytest.mark.timeout(1)
+    def test_chunks_integrity(self):
+        da = xd.DataArray(np.random.rand(1000, 100), dims=("time", "distance"))
+        dl = DataArrayLoader(da, {"time": 100})
+        chunks = [chunk for chunk in dl]
+        result = xd.concatenate(chunks)
+        assert result.equals(da)
 
 
 class TestProcessing:

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -34,6 +34,12 @@ class TestDataArrayLoader:
         assert dl.chunk_size == 100
         dl.stop()
 
+    @pytest.mark.timeout(1)
+    def test_context_manager(self):
+        da = xd.DataArray(np.random.rand(1000, 100), dims=("time", "distance"))
+        with DataArrayLoader(da, {"time": 100}) as dl:
+            assert dl.da is da
+
 
 class TestProcessing:
     def test_stateful(self, tmp_path):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -6,6 +6,7 @@ import hdf5plugin
 import numpy as np
 import obspy
 import pandas as pd
+import pytest
 import scipy.signal as sp
 
 import xdas as xd
@@ -22,6 +23,16 @@ from xdas.processing import (
 )
 from xdas.signal import sosfilt
 from xdas.synthetics import wavelet_wavefronts
+
+
+class TestDataArrayLoader:
+    @pytest.mark.timeout(1)
+    def test_init_and_stop(self):
+        da = xd.DataArray(np.random.rand(1000, 100), dims=("time", "distance"))
+        dl = DataArrayLoader(da, {"time": 100})
+        assert dl.chunk_dim == "time"
+        assert dl.chunk_size == 100
+        dl.stop()
 
 
 class TestProcessing:
@@ -48,6 +59,34 @@ class TestProcessing:
 
         # test
         assert result1.equals(result2)
+
+    def test_small_last_chunk(self, tmp_path):
+        da = xd.DataArray(
+            data=np.random.randn(1001, 100),
+            coords={
+                "time": xd.Coordinate["interpolated"].from_block(0, 1001, 0.01),
+                "distance": xd.Coordinate["interpolated"].from_block(0, 100, 10.0),
+            },
+        )
+
+        # declare processing sequence
+        sos = sp.iirfilter(4, 0.1, btype="lowpass", output="sos")
+        sequence = Sequential([Partial(sosfilt, sos, ..., dim="time", zi=...)])
+
+        # monolithic processing
+        result1 = sequence(da)
+
+        # chunked processing
+        data_loader = DataArrayLoader(da, chunks={"time": 100})
+        for da in data_loader:
+            pass
+        # data_writer = DataArrayWriter(tmp_path)
+        # result2 = process(
+        #     sequence, data_loader, data_writer
+        # )  # resets the sequence by default
+
+        # # test
+        # assert result1.equals(result2)
 
 
 class TestDataFrameWriter:

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -49,6 +49,18 @@ class TestDataArrayLoader:
         result = xd.concatenate(chunks)
         assert result.equals(da)
 
+    @pytest.mark.timeout(1)
+    def test_error_handling(self):
+        da = xd.DataArray(np.random.rand(1000, 100), dims=("time", "distance"))
+        with pytest.raises(TypeError):
+            DataArrayLoader(None, None)
+        with pytest.raises(TypeError):
+            DataArrayLoader(da, 100)
+        with pytest.raises(ValueError):
+            DataArrayLoader(da, {"space": 100})
+        with pytest.raises(ValueError):
+            DataArrayLoader(da, {"time": 2000})
+
 
 class TestProcessing:
     def test_stateful(self, tmp_path):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -197,6 +197,17 @@ class TestDataFrameWriter:
         result = pd.read_csv(tmp_path / "output.csv")
         assert result.equals(expected)
 
+    def test_missing_directory(self, tmp_path):
+        with pytest.raises(OSError):
+            xp.DataFrameWriter(tmp_path / "not_a_directory" / "output.csv")
+        dirpath = tmp_path / "some_directory" / "output.csv"
+        xp.DataFrameWriter(dirpath, create_dirs=True)
+
+    def test_passing_wrong_input(self, tmp_path):
+        dw = xp.DataFrameWriter(tmp_path / "output.csv")
+        with pytest.raises(TypeError):
+            dw.submit(None)
+
 
 class TestZMQ:
     def _publish_and_subscribe(self, packets, address, encoding=None):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -12,44 +12,33 @@ import scipy.signal as sp
 import xdas as xd
 import xdas.processing as xp
 from xdas.atoms import Partial, Sequential
-from xdas.processing import (
-    DataArrayLoader,
-    DataArrayWriter,
-    DataFrameWriter,
-    StreamWriter,
-    ZMQPublisher,
-    ZMQSubscriber,
-    process,
-)
 from xdas.signal import sosfilt
 from xdas.synthetics import wavelet_wavefronts
 
 
 class TestDataArrayLoader:
-
     def test_init(self):
         da = xd.DataArray(np.random.rand(1000, 100), dims=("time", "distance"))
-        dl = DataArrayLoader(da, {"time": 100})
+        dl = xp.DataArrayLoader(da, {"time": 100})
         assert dl.da is da
         assert dl.chunk_dim == "time"
         assert dl.chunk_size == 100
-        assert dl.prefetch == 1
+        assert dl.max_buffers == 1
         assert dl.max_workers == 1
         assert len(dl) == 10
 
     @pytest.mark.parametrize(
-        "prefetch,max_workers",
+        "max_buffers,max_workers",
         [
-            (0, 1),
             (1, 1),
             (2, 2),
             (4, 2),
             (8, 4),
         ],
     )
-    def test_chunks_integrity(self, prefetch, max_workers):
+    def test_chunks_integrity(self, max_buffers, max_workers):
         da = xd.DataArray(np.random.rand(1000, 100), dims=("time", "distance"))
-        dl = DataArrayLoader(da, {"time": 100}, prefetch, max_workers)
+        dl = xp.DataArrayLoader(da, {"time": 100}, max_buffers, max_workers)
         chunks = [chunk for chunk in dl]
         result = xd.concatenate(chunks)
         assert result.equals(da)
@@ -57,13 +46,49 @@ class TestDataArrayLoader:
     def test_error_handling(self):
         da = xd.DataArray(np.random.rand(1000, 100), dims=("time", "distance"))
         with pytest.raises(TypeError):
-            DataArrayLoader(None, None)
+            xp.DataArrayLoader(None, None)
         with pytest.raises(TypeError):
-            DataArrayLoader(da, 100)
+            xp.DataArrayLoader(da, 100)
         with pytest.raises(ValueError):
-            DataArrayLoader(da, {"space": 100})
+            xp.DataArrayLoader(da, {"space": 100})
         with pytest.raises(ValueError):
-            DataArrayLoader(da, {"time": 2000})
+            xp.DataArrayLoader(da, {"time": 2000})
+
+
+class TestDataArrayWriter:
+    def test_init(self, tmp_path):
+        dw = xp.DataArrayWriter(tmp_path)
+        assert dw.dirpath == str(tmp_path)
+
+    @pytest.mark.parametrize(
+        "max_buffers,max_workers",
+        [
+            (1, 1),
+            (2, 2),
+            (4, 2),
+            (8, 4),
+        ],
+    )
+    def test_chunk_integrity(self, max_buffers, max_workers, tmp_path):
+        expected = xd.DataArray(np.random.rand(1000, 100), dims=("time", "distance"))
+        dw = xp.DataArrayWriter(tmp_path, None, max_buffers, max_workers)
+        chunks = xd.split(expected, 10, dim="time")
+        for chunk in chunks:
+            dw.submit(chunk)
+        result = dw.result()
+        result = result.load()
+        assert result.equals(expected)
+
+    def test_missing_directory(self, tmp_path):
+        with pytest.raises(OSError):
+            xp.DataArrayWriter("not_a_directory")
+        dirpath = tmp_path / "some_directory"
+        xp.DataArrayWriter(dirpath, create_dirs=True)
+
+    def test_passing_wrong_input(self, tmp_path):
+        dw = xp.DataArrayWriter(tmp_path, create_dirs=True)
+        with pytest.raises(TypeError):
+            dw.submit(None)
 
 
 class TestProcessing:
@@ -82,9 +107,9 @@ class TestProcessing:
         result1 = sequence(da)
 
         # chunked processing
-        data_loader = DataArrayLoader(da, chunks={"time": 100})
-        data_writer = DataArrayWriter(tmp_path)
-        result2 = process(
+        data_loader = xp.DataArrayLoader(da, chunks={"time": 100})
+        data_writer = xp.DataArrayWriter(tmp_path)
+        result2 = xp.process(
             sequence, data_loader, data_writer
         )  # resets the sequence by default
 
@@ -108,11 +133,11 @@ class TestProcessing:
         result1 = sequence(da)
 
         # chunked processing
-        data_loader = DataArrayLoader(da, chunks={"time": 100})
+        data_loader = xp.DataArrayLoader(da, chunks={"time": 100})
         for da in data_loader:
             pass
-        # data_writer = DataArrayWriter(tmp_path)
-        # result2 = process(
+        # data_writer = xp.DataArrayWriter(tmp_path)
+        # result2 = xp.process(
         #     sequence, data_loader, data_writer
         # )  # resets the sequence by default
 
@@ -122,8 +147,8 @@ class TestProcessing:
 
 class TestDataFrameWriter:
     def test_write_and_result(self, tmp_path):
-        # Create a DataFrameWriter instance
-        writer = DataFrameWriter(tmp_path / "output.csv")
+        # Create a xp.DataFrameWriter instance
+        writer = xp.DataFrameWriter(tmp_path / "output.csv")
 
         # Create a DataFrame to write
         df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
@@ -145,8 +170,8 @@ class TestDataFrameWriter:
         assert output_df.equals(df)
 
     def test_write_multiple_dataframes(self, tmp_path):
-        # Create a DataFrameWriter instance
-        writer = DataFrameWriter(tmp_path / "output.csv")
+        # Create a xp.DataFrameWriter instance
+        writer = xp.DataFrameWriter(tmp_path / "output.csv")
 
         # Create multiple DataFrames to write
         df1 = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
@@ -171,8 +196,8 @@ class TestDataFrameWriter:
         assert output_df.equals(expected_result)
 
     def test_write_empty_dataframe(self, tmp_path):
-        # Create a DataFrameWriter instance
-        writer = DataFrameWriter(tmp_path / "output.csv")
+        # Create a xp.DataFrameWriter instance
+        writer = xp.DataFrameWriter(tmp_path / "output.csv")
 
         # Create an empty DataFrame to write
         df = pd.DataFrame()
@@ -190,9 +215,9 @@ class TestDataFrameWriter:
         assert Path(writer.path).exists()
 
     def test_write_and_result_with_existing_file(self, tmp_path):
-        # Create a DataFrameWriter instance
+        # Create a xp.DataFrameWriter instance
         output_path = tmp_path / "output.csv"
-        writer = DataFrameWriter(output_path)
+        writer = xp.DataFrameWriter(output_path)
 
         # Create a DataFrame to write
         df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
@@ -217,7 +242,7 @@ class TestDataFrameWriter:
         new_df = pd.DataFrame({"A": [7, 8, 9], "B": [10, 11, 12]})
 
         # Create new Writer instance with the same output file
-        writer = DataFrameWriter(output_path)
+        writer = xp.DataFrameWriter(output_path)
 
         # Write the new DataFrame asynchronously
         writer.write(new_df)
@@ -236,7 +261,7 @@ class TestDataFrameWriter:
 
 class TestZMQ:
     def _publish_and_subscribe(self, packets, address, encoding=None):
-        publisher = ZMQPublisher(address, encoding)
+        publisher = xp.ZMQPublisher(address, encoding)
 
         def publish():
             for packet in packets:
@@ -245,7 +270,7 @@ class TestZMQ:
 
         threading.Thread(target=publish).start()
 
-        subscriber = ZMQSubscriber(address)
+        subscriber = xp.ZMQSubscriber(address)
         result = []
         for n, packet in enumerate(subscriber, start=1):
             result.append(packet)
@@ -299,11 +324,11 @@ class TestStreamWriter:
             dim={"distance": "time"},
         )
 
-        data_loader = DataArrayLoader(da, chunks={"time": 100})
+        data_loader = xp.DataArrayLoader(da, chunks={"time": 100})
 
         kw_merge = {"method": 1}
         kw_write = {"reclen": 4096}
-        data_writer = StreamWriter(
+        data_writer = xp.StreamWriter(
             tmp_path, "M", kw_merge, kw_write, output_format="SDS"
         )
 
@@ -356,11 +381,11 @@ class TestStreamWriter:
             dim={"distance": "time"},
         )
 
-        data_loader = DataArrayLoader(da, chunks={"time": 100})
+        data_loader = xp.DataArrayLoader(da, chunks={"time": 100})
 
         kw_merge = {"method": 1}
         kw_write = {"reclen": 4096}
-        data_writer = StreamWriter(
+        data_writer = xp.StreamWriter(
             tmp_path, "M", kw_merge, kw_write, output_format="SDS"
         )
 
@@ -414,12 +439,14 @@ class TestStreamWriter:
             dim={"distance": "time"},
         )
 
-        data_loader = DataArrayLoader(da, chunks={"time": 100})
+        data_loader = xp.DataArrayLoader(da, chunks={"time": 100})
 
         path = tmp_path / "flat_output.mseed"
         kw_merge = {"method": 1}
         kw_write = {"reclen": 4096}
-        data_writer = StreamWriter(path, "M", kw_merge, kw_write, output_format="flat")
+        data_writer = xp.StreamWriter(
+            path, "M", kw_merge, kw_write, output_format="flat"
+        )
 
         st = xp.process(atom, data_loader, data_writer)
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -76,7 +76,6 @@ class TestDataArrayWriter:
         for chunk in chunks:
             dw.submit(chunk)
         result = dw.result()
-        result = result.load()
         assert result.equals(expected)
 
     def test_missing_directory(self, tmp_path):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -145,117 +145,57 @@ class TestProcessing:
 
 
 class TestDataFrameWriter:
-    def test_write_and_result(self, tmp_path):
-        # Create a xp.DataFrameWriter instance
-        writer = xp.DataFrameWriter(tmp_path / "output.csv")
+    def test_init(self, tmp_path):
+        dw = xp.DataFrameWriter(tmp_path / "output.csv")
+        assert dw.path == str(tmp_path / "output.csv")
+        assert dw.parse_dates is None
 
-        # Create a DataFrame to write
-        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+    def test_single_dataframe(self, tmp_path):
+        dw = xp.DataFrameWriter(tmp_path / "output.csv")
+        expected = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        dw.submit(expected)
+        result = dw.result()
+        assert result.equals(expected)
+        assert Path(dw.path).exists()
+        result = pd.read_csv(dw.path)
+        assert result.equals(expected)
 
-        # Write the DataFrame asynchronously
-        writer.write(df)
-
-        # Get the result (wait for the asynchronous task to complete)
-        result = writer.result()
-
-        # Check if the result matches the original DataFrame
-        assert result.equals(df)
-
-        # Check if the output file exists
-        assert Path(writer.path).exists()
-
-        # Check if the output file contains the correct data
-        output_df = pd.read_csv(writer.path)
-        assert output_df.equals(df)
-
-    def test_write_multiple_dataframes(self, tmp_path):
-        # Create a xp.DataFrameWriter instance
-        writer = xp.DataFrameWriter(tmp_path / "output.csv")
-
-        # Create multiple DataFrames to write
+    def test_multiple_dataframes(self, tmp_path):
+        dw = xp.DataFrameWriter(tmp_path / "output.csv")
         df1 = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
         df2 = pd.DataFrame({"A": [7, 8, 9], "B": [10, 11, 12]})
-
-        # Write the DataFrames asynchronously
-        writer.write(df1)
-        writer.write(df2)
-
-        # Get the result (wait for the asynchronous task to complete)
-        result = writer.result()
-
-        # Check if the result matches the concatenated DataFrames
-        expected_result = pd.concat([df1, df2], ignore_index=True)
-        assert result.equals(expected_result)
-
-        # Check if the output file exists
-        assert Path(writer.path).exists()
-
-        # Check if the output file contains the correct data
-        output_df = pd.read_csv(writer.path)
-        assert output_df.equals(expected_result)
+        dw.submit(df1)
+        dw.submit(df2)
+        result = dw.result()
+        expected = pd.concat([df1, df2], ignore_index=True)
+        assert result.equals(expected)
+        assert Path(dw.path).exists()
+        result = pd.read_csv(dw.path)
+        assert result.equals(expected)
 
     def test_write_empty_dataframe(self, tmp_path):
-        # Create a xp.DataFrameWriter instance
-        writer = xp.DataFrameWriter(tmp_path / "output.csv")
+        dw = xp.DataFrameWriter(tmp_path / "output.csv")
+        expected = pd.DataFrame()
+        dw.submit(expected)
+        result = dw.result()
+        assert result.equals(expected)
+        assert Path(dw.path).exists()
 
-        # Create an empty DataFrame to write
-        df = pd.DataFrame()
+    def test_with_existing_file(self, tmp_path):
+        dw1 = xp.DataFrameWriter(tmp_path / "output.csv")
+        df1 = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        dw1.submit(df1)
+        result = dw1.result()
 
-        # Write the DataFrame asynchronously
-        writer.write(df)
+        dw2 = xp.DataFrameWriter(tmp_path / "output.csv")
+        df2 = pd.DataFrame({"A": [7, 8, 9], "B": [10, 11, 12]})
+        dw2.submit(df2)
+        result = dw2.result()
 
-        # Get the result (wait for the asynchronous task to complete)
-        result = writer.result()
-
-        # Check if the result matches the original DataFrame
-        assert result.equals(df)
-
-        # Check if the output file exists
-        assert Path(writer.path).exists()
-
-    def test_write_and_result_with_existing_file(self, tmp_path):
-        # Create a xp.DataFrameWriter instance
-        output_path = tmp_path / "output.csv"
-        writer = xp.DataFrameWriter(output_path)
-
-        # Create a DataFrame to write
-        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-
-        # Write the DataFrame asynchronously
-        writer.write(df)
-
-        # Get the result (wait for the asynchronous task to complete)
-        result = writer.result()
-
-        # Check if the result matches the original DataFrame
-        assert result.equals(df)
-
-        # Check if the output file exists
-        assert Path(writer.path).exists()
-
-        # Check if the output file contains the correct data
-        output_df = pd.read_csv(writer.path)
-        assert output_df.equals(df)
-
-        # Create a new DataFrame to write
-        new_df = pd.DataFrame({"A": [7, 8, 9], "B": [10, 11, 12]})
-
-        # Create new Writer instance with the same output file
-        writer = xp.DataFrameWriter(output_path)
-
-        # Write the new DataFrame asynchronously
-        writer.write(new_df)
-
-        # Get the result (wait for the asynchronous task to complete)
-        result = writer.result()
-
-        # Check if the result matches the concatenated DataFrames
-        expected_result = pd.concat([df, new_df], ignore_index=True)
-        assert result.equals(expected_result)
-
-        # Check if the output file contains the correct data
-        output_df = pd.read_csv(writer.path)
-        assert output_df.equals(expected_result)
+        expected = pd.concat([df1, df2], ignore_index=True)
+        assert result.equals(expected)
+        result = pd.read_csv(tmp_path / "output.csv")
+        assert result.equals(expected)
 
 
 class TestZMQ:

--- a/xdas/processing/core.py
+++ b/xdas/processing/core.py
@@ -1,10 +1,10 @@
 import os
-import threading
 from concurrent.futures import ThreadPoolExecutor
 from glob import glob
 from pathlib import Path
 from queue import Empty, Full, Queue
 from tempfile import TemporaryDirectory
+from threading import Condition, Thread
 
 import numpy as np
 import obspy
@@ -91,17 +91,17 @@ class DataArrayLoader:
 
     Iterate over the chunks
 
-    >>> for chunk in dl:  # doctest: +SKIP
-    >>>     process(chunk)  # doctest: +SKIP
+    >>> for chunk in dl:
+    ...     process(chunk)  # doctest: +SKIP
 
     Do not forget to stop it if you do not iterate over all chunks
 
     >>> dl.close()  # doctest: +SKIP
 
     For greater safety it is best to use it within a context manager:
-    >>> with DataArrayLoader(da, chunks) as dl:  # doctest: +SKIP
-    >>>     for chunk in dl:  # doctest: +SKIP
-    >>>         process(chunk)  # doctest: +SKIP
+    >>> with DataArrayLoader(da, chunks) as dl:
+    ...     for chunk in dl:
+    ...         process(chunk)  # doctest: +SKIP
 
     """
 
@@ -132,12 +132,12 @@ class DataArrayLoader:
         self.chunk_size = chunk_size
 
         # state
-        self._condition = threading.Condition()
+        self._condition = Condition()
         self._queue = Queue(maxsize=1)
         self._stop = False
 
         # initialize
-        self._thread = threading.Thread(target=self._produce)
+        self._thread = Thread(target=self._produce)
         self._thread.start()
 
     def __len__(self):
@@ -162,8 +162,8 @@ class DataArrayLoader:
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_type, exc, tb):
-        self.stop()
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.shutdown()
 
     @property
     def nbytes(self):
@@ -204,11 +204,14 @@ class DataArrayLoader:
             except Empty:
                 break
 
-    def stop(self):
+    def shutdown(self):
         self._stop = True
         with self._condition:
             self._condition.notify()
         self._thread.join()
+
+
+
 
 
 class RealTimeLoader(Observer):

--- a/xdas/processing/core.py
+++ b/xdas/processing/core.py
@@ -291,6 +291,20 @@ class DataFrameWriter:
         Weather to parse dates when reopening the csv file a the end of the process
     create_dirs : bool, optional
         Whether to create parent directories if they do not exist. Default is False.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import xdas.processing as xp
+
+    >>> dw = xp.DataFrameWriter("output.csv")
+    >>> for df in dfs:
+    ...     dw.submit(dfs)
+    >>> result = dw.result()  # doctest: +SKIP
+
+    >>> expected = pd.concat(dfs, ignore_index=True)
+    >>> assert result.equals(expected)  # doctest: +SKIP
+
     """
 
     def __init__(self, path, parse_dates=None, create_dirs=False):

--- a/xdas/processing/core.py
+++ b/xdas/processing/core.py
@@ -102,7 +102,7 @@ class DataArrayLoader:
 
     """
 
-    def __init__(self, da, chunks, prefetch=1, max_workers=1):
+    def __init__(self, da, chunks, max_buffers=1, max_workers=1):
         if not isinstance(da, DataArray):
             raise TypeError(f"`da` must by a DataArray object, not a {type(da)}")
         if not isinstance(chunks, dict) and len(chunks) == 1:
@@ -126,14 +126,14 @@ class DataArrayLoader:
         self.da = da
         self.chunk_dim = chunk_dim
         self.chunk_size = chunk_size
-        self.prefetch = prefetch
+        self.max_buffers = max_buffers
         self.max_workers = max_workers
 
     def __len__(self):
         div, mod = divmod(self.da.sizes[self.chunk_dim], self.chunk_size)
         return div if mod == 0 else div + 1
 
-    def __getitem__(self, idx):
+    def _get_chunk(self, idx):
         start = idx * self.chunk_size
         end = (idx + 1) * self.chunk_size
         query = {
@@ -148,8 +148,8 @@ class DataArrayLoader:
 
             futures = []
             try:
-                for _ in range(self.prefetch):
-                    futures.append(executor.submit(self.__getitem__, next(it)))
+                for _ in range(self.max_buffers):
+                    futures.append(executor.submit(self._get_chunk, next(it)))
             except StopIteration:
                 pass
 
@@ -158,7 +158,7 @@ class DataArrayLoader:
                 result = future.result()
 
                 try:
-                    futures.append(executor.submit(self.__getitem__, next(it)))
+                    futures.append(executor.submit(self._get_chunk, next(it)))
                 except StopIteration:
                     pass
 
@@ -224,40 +224,51 @@ class DataArrayWriter:
 
     """
 
-    def __init__(self, dirpath, encoding=None):
-        self.dirpath = str(dirpath) if isinstance(dirpath, Path) else dirpath
+    def __init__(
+        self, dirpath, encoding=None, max_buffers=1, max_workers=1, create_dirs=False
+    ):
+        dirpath = str(dirpath) if isinstance(dirpath, Path) else dirpath
+        if create_dirs:
+            os.makedirs(dirpath, exist_ok=True)
+        if not os.path.exists(dirpath):
+            raise OSError(f"no directory {dirpath}")
+        self.dirpath = dirpath
         self.encoding = encoding
-        self.queue = Queue(maxsize=1)
-        self.results = []
-        self.executor = ThreadPoolExecutor(1)
-        self.future = self.executor.submit(self.task)
+        self.max_buffers = max_buffers
+        self.max_workers = max_workers
+        self._executor = ThreadPoolExecutor(self.max_workers)
+        self._futures = []
+        self._results = []
+        self._count = 0
 
-    def write(self, da):
-        self.queue.put(da)
+    def submit(self, chunk):
+        if not isinstance(chunk, DataArray):
+            raise TypeError(f"`chunk` must by a DataArray object, not a {type(chunk)}")
+        if not len(self._futures) < self.max_buffers:
+            future = self._futures.pop(0)
+            result = future.result()
+            self._results.append(result)
+        self._futures.append(self._executor.submit(self._write, chunk, self._count))
+        self._count += 1
 
-    def task(self):
-        while True:
-            da = self.queue.get()
-            if da is None:
-                break
-            path = self.get_path(da)
-            if os.path.exists(path):
-                raise OSError(f"the file '{path}' already exists.")
-            else:
-                da.to_netcdf(path, encoding=self.encoding)
-            self.results.append(open_dataarray(path))
+    def write(self, chunk):
+        return self.submit(chunk)
 
-    def get_path(self, da):
-        datetime = np.datetime_as_string(da["time"][0].values, unit="s").replace(
-            ":", "-"
-        )
-        fname = f"{datetime}.nc"
-        return os.path.join(self.dirpath, fname)
+    def _write(self, chunk, count):
+        path = os.path.join(self.dirpath, f"{count:09d}")
+        chunk.to_netcdf(path, encoding=self.encoding)
+        return open_dataarray(path)
+
+    def shutdown(self):
+        self._executor.shutdown()
 
     def result(self):
-        self.queue.put(None)
-        self.future.result()
-        return concatenate(self.results)
+        while self._futures:
+            future = self._futures.pop(0)
+            result = future.result()
+            self._results.append(result)
+        self.shutdown()
+        return concatenate(self._results)
 
 
 class DataFrameWriter:

--- a/xdas/processing/core.py
+++ b/xdas/processing/core.py
@@ -97,6 +97,11 @@ class DataArrayLoader:
 
     >>> dl.close()  # doctest: +SKIP
 
+    For greater safety it is best to use it within a context manager:
+    >>> with DataArrayLoader(da, chunks) as dl:
+    >>>     for chunk in dl:
+    >>>         process(chunk)  # doctest: +SKIP
+
     """
 
     def __init__(self, da, chunks):

--- a/xdas/processing/core.py
+++ b/xdas/processing/core.py
@@ -79,7 +79,7 @@ class DataArrayLoader:
         ``{"dim": int}``. The key correspond with the dimension (usually "time"),
         and the value is an integer indicating the size of the chunk (in samples)
         along that dimension.
-    prefetch : int, default=1
+    max_buffers : int, default=1
         The maximum number of chunks to load into memory at the same time.
     max_workers : int, default=1
         The maximum number of thread used to load the chunks.
@@ -210,17 +210,25 @@ class DataArrayWriter:
         to exist and be empty.
     encoding : dict
         The encoding to use when dumping the DataArrays to bytes.
+    max_buffers : int, default=1
+        The maximum number of chunks to load into memory at the same time.
+    max_workers : int, default=1
+        The maximum number of thread used to load the chunks.
+    create_dirs : bool, optional
+        Whether to create parent directories if they do not exist. Default is False.
 
     Examples
     --------
-    >>> import os, shutil
-    >>> from xdas.processing import DataArrayWriter
+    >>> import xdas.processing as xp
 
-    >>> dirpath = "output"
-    >>> if not os.path.exists(dirpath):
-    ...     os.makedirs(dirpath) # doctest: +SKIP
+    >>> expected = xd.DataArray(np.random.rand(1000, 100), dims=("time", "distance"))
 
-    >>> dw = DataArrayWriter(dirpath) # doctest: +SKIP
+    >>> dw = DataArrayWriter("some_path") 
+    >>> for chunk in chunks:
+    ...     dw.submit(chunk)
+    >>> result = dw.result 
+
+    >>> assert result.equals(expected)
 
     """
 

--- a/xdas/processing/core.py
+++ b/xdas/processing/core.py
@@ -13,6 +13,7 @@ import zmq
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
+from ..core.dataarray import DataArray
 from ..core.routines import concatenate, open_dataarray
 from .monitor import Monitor
 
@@ -90,7 +91,7 @@ class DataArrayLoader:
 
     Iterate over the chunks
 
-    >>> for chunk in dl:
+    >>> for chunk in dl:  # doctest: +SKIP
     >>>     process(chunk)  # doctest: +SKIP
 
     Do not forget to stop it if you do not iterate over all chunks
@@ -98,16 +99,37 @@ class DataArrayLoader:
     >>> dl.close()  # doctest: +SKIP
 
     For greater safety it is best to use it within a context manager:
-    >>> with DataArrayLoader(da, chunks) as dl:
-    >>>     for chunk in dl:
+    >>> with DataArrayLoader(da, chunks) as dl:  # doctest: +SKIP
+    >>>     for chunk in dl:  # doctest: +SKIP
     >>>         process(chunk)  # doctest: +SKIP
 
     """
 
     def __init__(self, da, chunks):
         # parse
+        if not isinstance(da, DataArray):
+            raise TypeError(f"`da` must by a DataArray object, not a {type(da)}")
+        if not isinstance(chunks, dict) and len(chunks) == 1:
+            raise TypeError(
+                "`chunks` must be a dict that maps a unique "
+                "dimension to a unique size: {'dim': size}"
+            )
+        ((chunk_dim, chunk_size),) = chunks.items()
+        chunk_dim = str(chunk_dim)
+        chunk_size = int(chunk_size)
+        if chunk_dim not in da.dims:
+            raise ValueError(
+                f"chunking dimension {chunk_dim} not "
+                f"found in `da` dimensions {da.dims}"
+            )
+        if chunk_size > da.sizes[chunk_dim]:
+            raise ValueError(
+                f"chunking size {chunk_size} is greater than `da` "
+                f"size {da.sizes[chunk_dim]} along dim {chunk_dim}"
+            )
         self.da = da
-        ((self.chunk_dim, self.chunk_size),) = chunks.items()
+        self.chunk_dim = chunk_dim
+        self.chunk_size = chunk_size
 
         # state
         self._condition = threading.Condition()

--- a/xdas/processing/core.py
+++ b/xdas/processing/core.py
@@ -3,7 +3,7 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 from glob import glob
 from pathlib import Path
-from queue import Queue, Empty, Full
+from queue import Empty, Full, Queue
 from tempfile import TemporaryDirectory
 
 import numpy as np
@@ -88,7 +88,13 @@ class DataArrayLoader:
     >>> chunks = {"time": 1000}
     >>> dl = DataArrayLoader(da, chunks)  # doctest: +SKIP
 
+    Iterate over the chunks
+
+    >>> for chunk in dl:
+    >>>     process(chunk)  # doctest: +SKIP
+
     Do not forget to stop it if you do not iterate over all chunks
+
     >>> dl.close()  # doctest: +SKIP
 
     """
@@ -125,6 +131,12 @@ class DataArrayLoader:
 
     def __next__(self):
         return self._consume()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.stop()
 
     @property
     def nbytes(self):

--- a/xdas/processing/core.py
+++ b/xdas/processing/core.py
@@ -219,16 +219,17 @@ class DataArrayWriter:
 
     Examples
     --------
+    >>> import xdas as xd
     >>> import xdas.processing as xp
 
     >>> expected = xd.DataArray(np.random.rand(1000, 100), dims=("time", "distance"))
 
-    >>> dw = DataArrayWriter("some_path")
+    >>> dw = DataArrayWriter("some_path")  # doctest: +SKIP
     >>> for chunk in chunks:
-    ...     dw.submit(chunk)
-    >>> result = dw.result
+    ...     dw.submit(chunk)  # doctest: +SKIP
+    >>> result = dw.result  # doctest: +SKIP
 
-    >>> assert result.equals(expected)
+    >>> assert result.equals(expected)  # doctest: +SKIP
 
     """
 
@@ -299,10 +300,10 @@ class DataFrameWriter:
 
     >>> dw = xp.DataFrameWriter("output.csv")
     >>> for df in dfs:
-    ...     dw.submit(dfs)
+    ...     dw.submit(dfs). # doctest: +SKIP
     >>> result = dw.result()  # doctest: +SKIP
 
-    >>> expected = pd.concat(dfs, ignore_index=True)
+    >>> expected = pd.concat(dfs, ignore_index=True)  # doctest: +SKIP
     >>> assert result.equals(expected)  # doctest: +SKIP
 
     """
@@ -319,22 +320,22 @@ class DataFrameWriter:
         self._executor = ThreadPoolExecutor(1)
         self._future = None
 
-    def submit(self, chunk):
-        if not isinstance(chunk, pd.DataFrame):
-            raise TypeError(f"`chunk` must by a DataFrame object, not a {type(chunk)}")
+    def submit(self, df):
+        if not isinstance(df, pd.DataFrame):
+            raise TypeError(f"`df` must by a DataFrame object, not a {type(df)}")
         if self._future is not None:
             self._future.result()
-        self._future = self._executor.submit(self._write, chunk)
+        self._future = self._executor.submit(self._write, df)
 
-    def write(self, chunk):
-        return self.submit(chunk)
+    def write(self, df):
+        return self.submit(df)
 
-    def _write(self, chunk):
-        if chunk is not None:
+    def _write(self, df):
+        if df is not None:
             if not os.path.exists(self.path):
-                chunk.to_csv(self.path, mode="w", header=True, index=False)
+                df.to_csv(self.path, mode="w", header=True, index=False)
             else:
-                chunk.to_csv(self.path, mode="a", header=False, index=False)
+                df.to_csv(self.path, mode="a", header=False, index=False)
 
     def shutdown(self):
         self._executor.shutdown()
@@ -453,14 +454,10 @@ class StreamWriter:
         self.kw_merge = kw_merge if kw_merge is not None else {}
         self.kw_write = kw_write if kw_write is not None else {}
         self.output_format = output_format
-        self.queue = Queue(maxsize=1)
-        self.executor = ThreadPoolExecutor(1)
-        self.future = self.executor.submit(self.task)
+        self._executor = ThreadPoolExecutor(1)
+        self._future = None
 
-    def to_SDS(self, st):
-        """
-        Convert and write the Stream to the SDS file structure.
-        """
+    def _to_SDS(self, st):
         for tr in st:
             new_st = obspy.Stream()
             new_st += tr
@@ -483,10 +480,7 @@ class StreamWriter:
             sds_path = os.path.join(dirpath, fname)
             new_st.write(sds_path, format="MSEED", **self.kw_write)
 
-    def to_flat(self, st):
-        """
-        Convert and write the Stream to a single miniseed file.
-        """
+    def _to_flat(self, st):
         new_st = obspy.Stream()
         for tr in st:
             tmp_st = obspy.Stream()
@@ -498,48 +492,32 @@ class StreamWriter:
                 new_st += new_tr
         new_st.write(os.path.join(self.dirpath, self.fname), **self.kw_write)
 
+    def submit(self, st):
+        if not isinstance(st, obspy.Stream):
+            raise TypeError(f"`st` must by a DataFrame object, not a {type(st)}")
+        if self._future is not None:
+            self._future.result()
+        self._future = self._executor.submit(self._write, st)
+
     def write(self, st):
-        """
-        Writes a Stream to the queue for asynchronous writing.
+        return self.submit(st)
 
-        Parameters
-        ----------
-        st : obspy.Stream
-            The Stream to be written.
-        """
-        self.queue.put(st)
+    def _write(self, st):
+        st.write(f"{self.dirpath}/{st[0].stats.starttime}_tmp.mseed", **self.kw_write)
 
-    def task(self):
-        """
-        The asynchronous task that writes the Stream to a temporary miniseed file.
-        """
-        while True:
-            st = self.queue.get()
-            if st is None:
-                break
-            st.write(
-                f"{self.dirpath}/{st[0].stats.starttime}_tmp.mseed", **self.kw_write
-            )
+    def shutdown(self):
+        self._executor.shutdown()
 
     def result(self):
-        """
-        Waits for the asynchronous task to complete, format the data into the chosen format, delete the temporary files
-        and returns the one single merged Stream read from the temporary files.
-
-        Returns
-        -------
-        obspy.Stream
-            Returns one single merged Stream read from the temporary files.
-        """
-        self.queue.put(None)
-        self.future.result()
+        self._future.result()
+        self.shutdown()
         pattern = f"{self.dirpath}/*_tmp.mseed"
         out = obspy.read(pattern)
         out = out.merge(**self.kw_merge)
         if self.output_format == "flat":
-            self.to_flat(out)
+            self._to_flat(out)
         elif self.output_format == "SDS":
-            self.to_SDS(out)
+            self._to_SDS(out)
         files_to_remove = glob(pattern)
         for file in files_to_remove:
             os.remove(file)

--- a/xdas/processing/core.py
+++ b/xdas/processing/core.py
@@ -1,8 +1,9 @@
 import os
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from glob import glob
 from pathlib import Path
-from queue import Queue
+from queue import Queue, Empty, Full
 from tempfile import TemporaryDirectory
 
 import numpy as np
@@ -87,19 +88,24 @@ class DataArrayLoader:
     >>> chunks = {"time": 1000}
     >>> dl = DataArrayLoader(da, chunks)  # doctest: +SKIP
 
-    Create chunks along both dimensions
-
-    >>> chunks2 = {"time": 1000, "distance": 10}
-    >>> dl2 = DataArrayLoader(da, chunks2)  # doctest: +SKIP
+    Do not forget to stop it if you do not iterate over all chunks
+    >>> dl.close()  # doctest: +SKIP
 
     """
 
     def __init__(self, da, chunks):
+        # parse
         self.da = da
         ((self.chunk_dim, self.chunk_size),) = chunks.items()
-        self.queue = Queue(maxsize=1)
-        self.executor = ThreadPoolExecutor(1)
-        self.future = self.executor.submit(self.task)
+
+        # state
+        self._condition = threading.Condition()
+        self._queue = Queue(maxsize=1)
+        self._stop = False
+
+        # initialize
+        self._thread = threading.Thread(target=self._produce)
+        self._thread.start()
 
     def __len__(self):
         div, mod = divmod(self.da.sizes[self.chunk_dim], self.chunk_size)
@@ -118,21 +124,52 @@ class DataArrayLoader:
         return self
 
     def __next__(self):
-        chunk = self.queue.get()
-        if chunk is None:
-            raise StopIteration
-        else:
-            return chunk
+        return self._consume()
 
     @property
     def nbytes(self):
         return self.da.nbytes
 
-    def task(self):
+    def _produce(self):
         for idx in range(len(self)):
-            data = self[idx]
-            self.queue.put(data)
-        self.queue.put(None)
+            chunk = self[idx]
+
+            with self._condition:
+                while True:
+                    if self._stop:
+                        self._clear()
+                        break
+                    try:
+                        self._queue.put_nowait(chunk)
+                        break
+                    except Full:
+                        self._condition.wait()
+
+        self._queue.put(None)
+
+    def _consume(self):
+        chunk = self._queue.get()
+
+        if chunk is None:
+            raise StopIteration
+
+        with self._condition:
+            self._condition.notify()
+
+        return chunk
+
+    def _clear(self):
+        while True:
+            try:
+                self._queue.get_nowait()
+            except Empty:
+                break
+
+    def stop(self):
+        self._stop = True
+        with self._condition:
+            self._condition.notify()
+        self._thread.join()
 
 
 class RealTimeLoader(Observer):

--- a/xdas/processing/core.py
+++ b/xdas/processing/core.py
@@ -2,9 +2,8 @@ import os
 from concurrent.futures import ThreadPoolExecutor
 from glob import glob
 from pathlib import Path
-from queue import Empty, Full, Queue
+from queue import Queue
 from tempfile import TemporaryDirectory
-from threading import Condition, Thread
 
 import numpy as np
 import obspy
@@ -68,15 +67,22 @@ class DataArrayLoader:
     """
     A class to handle data chunked data ingestion.
 
+    To optimize I/O latencies, chunks are loaded before they are used asynchronously
+    in a buffer as soon as the iterator is created.
+
     Parameters
     ----------
-    da : ``DataArray``, ``DataCollection``
-        The (virtual) DataArray or DataCollection that contains the data to be chunked
+    da : ``DataArray``
+        The (virtual) DataArray that contains the data to be chunked
     chunks : dict
         The sizes of the chunks along each dimension. Needs to be of the form:
-        ``{"dim": int}``. Each key needs to correspond with a dimension (either "time"
-        or "distance"), and each value is an integer indicating the size of the chunk
-        (in samples) along that dimension.
+        ``{"dim": int}``. The key correspond with the dimension (usually "time"),
+        and the value is an integer indicating the size of the chunk (in samples)
+        along that dimension.
+    prefetch : int, default=1
+        The maximum number of chunks to load into memory at the same time.
+    max_workers : int, default=1
+        The maximum number of thread used to load the chunks.
 
     Examples
     --------
@@ -94,25 +100,15 @@ class DataArrayLoader:
     >>> for chunk in dl:
     ...     process(chunk)  # doctest: +SKIP
 
-    Do not forget to stop it if you do not iterate over all chunks
-
-    >>> dl.close()  # doctest: +SKIP
-
-    For greater safety it is best to use it within a context manager:
-    >>> with DataArrayLoader(da, chunks) as dl:
-    ...     for chunk in dl:
-    ...         process(chunk)  # doctest: +SKIP
-
     """
 
-    def __init__(self, da, chunks):
-        # parse
+    def __init__(self, da, chunks, prefetch=1, max_workers=1):
         if not isinstance(da, DataArray):
             raise TypeError(f"`da` must by a DataArray object, not a {type(da)}")
         if not isinstance(chunks, dict) and len(chunks) == 1:
             raise TypeError(
                 "`chunks` must be a dict that maps a unique "
-                "dimension to a unique size: {'dim': size}"
+                "dimension to a unique size: {'dim': int}"
             )
         ((chunk_dim, chunk_size),) = chunks.items()
         chunk_dim = str(chunk_dim)
@@ -130,15 +126,8 @@ class DataArrayLoader:
         self.da = da
         self.chunk_dim = chunk_dim
         self.chunk_size = chunk_size
-
-        # state
-        self._condition = Condition()
-        self._queue = Queue(maxsize=1)
-        self._stop = False
-
-        # initialize
-        self._thread = Thread(target=self._produce)
-        self._thread.start()
+        self.prefetch = prefetch
+        self.max_workers = max_workers
 
     def __len__(self):
         div, mod = divmod(self.da.sizes[self.chunk_dim], self.chunk_size)
@@ -154,64 +143,30 @@ class DataArrayLoader:
         return self.da[query].load()
 
     def __iter__(self):
-        return self
+        with ThreadPoolExecutor(self.max_workers) as executor:
+            it = iter(range(len(self)))
 
-    def __next__(self):
-        return self._consume()
+            futures = []
+            try:
+                for _ in range(self.prefetch):
+                    futures.append(executor.submit(self.__getitem__, next(it)))
+            except StopIteration:
+                pass
 
-    def __enter__(self):
-        return self
+            while futures:
+                future = futures.pop(0)
+                result = future.result()
 
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.shutdown()
+                try:
+                    futures.append(executor.submit(self.__getitem__, next(it)))
+                except StopIteration:
+                    pass
+
+                yield result
 
     @property
     def nbytes(self):
         return self.da.nbytes
-
-    def _produce(self):
-        for idx in range(len(self)):
-            chunk = self[idx]
-
-            with self._condition:
-                while True:
-                    if self._stop:
-                        self._clear()
-                        break
-                    try:
-                        self._queue.put_nowait(chunk)
-                        break
-                    except Full:
-                        self._condition.wait()
-
-        self._queue.put(None)
-
-    def _consume(self):
-        chunk = self._queue.get()
-
-        if chunk is None:
-            raise StopIteration
-
-        with self._condition:
-            self._condition.notify()
-
-        return chunk
-
-    def _clear(self):
-        while True:
-            try:
-                self._queue.get_nowait()
-            except Empty:
-                break
-
-    def shutdown(self):
-        self._stop = True
-        with self._condition:
-            self._condition.notify()
-        self._thread.join()
-
-
-
 
 
 class RealTimeLoader(Observer):

--- a/xdas/processing/core.py
+++ b/xdas/processing/core.py
@@ -223,10 +223,10 @@ class DataArrayWriter:
 
     >>> expected = xd.DataArray(np.random.rand(1000, 100), dims=("time", "distance"))
 
-    >>> dw = DataArrayWriter("some_path") 
+    >>> dw = DataArrayWriter("some_path")
     >>> for chunk in chunks:
     ...     dw.submit(chunk)
-    >>> result = dw.result 
+    >>> result = dw.result
 
     >>> assert result.equals(expected)
 
@@ -286,78 +286,52 @@ class DataFrameWriter:
     Parameters
     ----------
     path : str
-        The path to the CSV file.
-
-    Attributes
-    ----------
-    path : str
-        The path to the CSV file.
-    parse_dates : list or bool
-        A list of columns to parse as dates.
-    queue : Queue
-        A queue to hold the DataFrames to be written.
-    executor : ThreadPoolExecutor
-        A thread pool executor for asynchronous writing.
-    future : Future
-        A future object representing the result of the asynchronous task.
-
-    Methods
-    -------
-    write(df)
-        Writes a DataFrame to the queue for asynchronous writing.
-    task()
-        The asynchronous task that writes the DataFrames to the CSV file.
-    result()
-        Waits for the asynchronous task to complete and returns the DataFrame read from the CSV file.
+        The path to the csv file.
+    parse_dates : bool, int, optional
+        Weather to parse dates when reopening the csv file a the end of the process
+    create_dirs : bool, optional
+        Whether to create parent directories if they do not exist. Default is False.
     """
 
-    def __init__(self, path, parse_dates=False):
+    def __init__(self, path, parse_dates=None, create_dirs=False):
+        dirpath = os.path.dirname(path)
+        if create_dirs:
+            if dirpath:
+                os.makedirs(dirpath, exist_ok=True)
+        if dirpath and not os.path.exists(dirpath):
+            raise OSError(f"no directory {dirpath}")
         self.path = str(path) if isinstance(path, Path) else path
         self.parse_dates = parse_dates
-        self.queue = Queue(maxsize=1)
-        self.executor = ThreadPoolExecutor(1)
-        self.future = self.executor.submit(self.task)
+        self._executor = ThreadPoolExecutor(1)
+        self._future = None
 
-    def write(self, df):
-        """
-        Writes a DataFrame to the queue for asynchronous writing.
+    def submit(self, chunk):
+        if not isinstance(chunk, pd.DataFrame):
+            raise TypeError(f"`chunk` must by a DataFrame object, not a {type(chunk)}")
+        if self._future is not None:
+            self._future.result()
+        self._future = self._executor.submit(self._write, chunk)
 
-        Parameters
-        ----------
-        df : pandas.DataFrame
-            The DataFrame to be written.
-        """
-        self.queue.put(df)
+    def write(self, chunk):
+        return self.submit(chunk)
 
-    def task(self):
-        """
-        The asynchronous task that writes the DataFrames to the CSV file.
-        """
-        while True:
-            df = self.queue.get()
-            if df is None:
-                break
+    def _write(self, chunk):
+        if chunk is not None:
             if not os.path.exists(self.path):
-                df.to_csv(self.path, mode="w", header=True, index=False)
+                chunk.to_csv(self.path, mode="w", header=True, index=False)
             else:
-                df.to_csv(self.path, mode="a", header=False, index=False)
+                chunk.to_csv(self.path, mode="a", header=False, index=False)
+
+    def shutdown(self):
+        self._executor.shutdown()
 
     def result(self):
-        """
-        Waits for the asynchronous task to complete and returns the DataFrame read from the CSV file.
-
-        Returns
-        -------
-        pandas.DataFrame
-            The DataFrame read from the CSV file.
-        """
-        self.queue.put(None)
-        self.future.result()
+        self._future.result()
+        self.shutdown()
         try:
-            out = pd.read_csv(self.path, parse_dates=self.parse_dates)
+            return pd.read_csv(self.path, parse_dates=self.parse_dates)
         except pd.errors.EmptyDataError:
-            out = pd.DataFrame()
-        return out
+            return pd.DataFrame()
 
 
 class StreamWriter:


### PR DESCRIPTION
It often happens that object like `xdas.processing.DataArrayLoader` or `xdas.processing.DataArrayWriter` stale because of improper thread management. This PR fixes that.  